### PR TITLE
refactor!: Add EventHandler + Combine

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ let client = OpenFeatureAPI.shared.getClient()
 let flagValue = client.getBooleanValue(key: "boolFlag", defaultValue: false)
 ```
 
-Setting a new provider or setting a new evaluation context might trigger asynchronous operations (e.g. fetching flag evaluations from the backend and store them in a local cache). It's advised to not interact with the OpenFeature client until the `ProviderReady` event has been emitted (see [Eventing](#eventing) below).
+Setting a new provider or setting a new evaluation context might trigger asynchronous operations (e.g. fetching flag evaluations from the backend and store them in a local cache). It's advised to not interact with the OpenFeature client until the `ProviderReady` event has been sent (see [Eventing](#eventing) below).
 
 ## 🌟 Features
 

--- a/README.md
+++ b/README.md
@@ -174,12 +174,13 @@ Some providers support additional events, such as `PROVIDER_CONFIGURATION_CHANGE
 Please refer to the documentation of the provider you're using to see what events are supported.
 
 ```swift
-OpenFeatureAPI.shared.addHandler(
-    observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
-)
-
-func readyEventEmitted(notification: NSNotification) {
-    // to something now that the provider is ready
+let cancellable = OpenFeatureAPI.shared.observe().sink { notification in
+    switch notification.name {
+    case ProviderEvent.ready.notificationName:
+        // ...
+    default:
+        // ...
+    }
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -174,9 +174,9 @@ Some providers support additional events, such as `PROVIDER_CONFIGURATION_CHANGE
 Please refer to the documentation of the provider you're using to see what events are supported.
 
 ```swift
-let cancellable = OpenFeatureAPI.shared.observe().sink { notification in
-    switch notification.name {
-    case ProviderEvent.ready.notificationName:
+let cancellable = OpenFeatureAPI.shared.observe().sink { event in
+    switch event {
+    case ProviderEvent.ready:
         // ...
     default:
         // ...

--- a/Sources/OpenFeature/Client.swift
+++ b/Sources/OpenFeature/Client.swift
@@ -11,15 +11,4 @@ public protocol Client: Features {
     /// Hooks are run in the order they're added in the before stage. They are run in reverse order for all
     /// other stages.
     func addHooks(_ hooks: any Hook...)
-
-    /// Add a handler for a particular provider event
-    ///  - Parameter observer: The object observing the event.
-    ///  - Parameter selector: The selector to call for this event.
-    ///  - Parameter event: The event to listen for.
-    func addHandler(observer: Any, selector: Selector, event: ProviderEvent)
-
-    /// Remove a handler for a particular provider event
-    ///  - Parameter observer: The object observing the event.
-    ///  - Parameter event: The event being listened to.
-    func removeHandler(observer: Any, event: ProviderEvent)
 }

--- a/Sources/OpenFeature/EventHandler.swift
+++ b/Sources/OpenFeature/EventHandler.swift
@@ -1,7 +1,7 @@
 import Foundation
 import Combine
 
-public class EventHandler: EventEmitter, EventPublisher {
+public class EventHandler: EventSender, EventPublisher {
     private let subject: CurrentValueSubject<ProviderEvent, Never>
 
     public init(_ state: ProviderEvent) {
@@ -12,7 +12,7 @@ public class EventHandler: EventEmitter, EventPublisher {
         return subject
     }
 
-    public func emit(
+    public func send(
         _ event: ProviderEvent
     ) {
         subject.send(event)
@@ -23,6 +23,6 @@ public protocol EventPublisher {
     func observe() -> CurrentValueSubject<ProviderEvent, Never>
 }
 
-public protocol EventEmitter {
-    func emit(_ event: ProviderEvent)
+public protocol EventSender {
+    func send(_ event: ProviderEvent)
 }

--- a/Sources/OpenFeature/EventHandler.swift
+++ b/Sources/OpenFeature/EventHandler.swift
@@ -23,6 +23,10 @@ public protocol EventPublisher {
     func observe() -> CurrentValueSubject<ProviderEvent, Never>
 }
 
+public protocol GlobalEventPublisher {
+    func observe() -> PassthroughSubject<ProviderEvent, Never>
+}
+
 public protocol EventSender {
     func send(_ event: ProviderEvent)
 }

--- a/Sources/OpenFeature/EventHandler.swift
+++ b/Sources/OpenFeature/EventHandler.swift
@@ -23,10 +23,6 @@ public protocol EventPublisher {
     func observe() -> CurrentValueSubject<ProviderEvent, Never>
 }
 
-public protocol GlobalEventPublisher {
-    func observe() -> PassthroughSubject<ProviderEvent, Never>
-}
-
 public protocol EventSender {
     func send(_ event: ProviderEvent)
 }

--- a/Sources/OpenFeature/EventHandler.swift
+++ b/Sources/OpenFeature/EventHandler.swift
@@ -2,20 +2,20 @@ import Foundation
 import Combine
 
 public class EventHandler: EventSender, EventPublisher {
-    private let subject: CurrentValueSubject<ProviderEvent, Never>
+    private let eventState: CurrentValueSubject<ProviderEvent, Never>
 
     public init(_ state: ProviderEvent) {
-        subject = CurrentValueSubject<ProviderEvent, Never>(ProviderEvent.stale)
+        eventState = CurrentValueSubject<ProviderEvent, Never>(ProviderEvent.stale)
     }
 
     public func observe() -> CurrentValueSubject<ProviderEvent, Never> {
-        return subject
+        return eventState
     }
 
     public func send(
         _ event: ProviderEvent
     ) {
-        subject.send(event)
+        eventState.send(event)
     }
 }
 

--- a/Sources/OpenFeature/EventHandler.swift
+++ b/Sources/OpenFeature/EventHandler.swift
@@ -8,8 +8,8 @@ public class EventHandler: EventSender, EventPublisher {
         eventState = CurrentValueSubject<ProviderEvent, Never>(ProviderEvent.stale)
     }
 
-    public func observe() -> CurrentValueSubject<ProviderEvent, Never> {
-        return eventState
+    public func observe() -> AnyPublisher<ProviderEvent, Never> {
+        return eventState.eraseToAnyPublisher()
     }
 
     public func send(
@@ -20,7 +20,7 @@ public class EventHandler: EventSender, EventPublisher {
 }
 
 public protocol EventPublisher {
-    func observe() -> CurrentValueSubject<ProviderEvent, Never>
+    func observe() -> AnyPublisher<ProviderEvent, Never>
 }
 
 public protocol EventSender {

--- a/Sources/OpenFeature/EventHandler.swift
+++ b/Sources/OpenFeature/EventHandler.swift
@@ -1,0 +1,50 @@
+import Foundation
+
+public class EventHandler: EventEmitter, EventPublisher {
+    private let providerNotificationCentre = NotificationCenter()
+
+    public init() {
+    }
+
+    public func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
+        providerNotificationCentre.addObserver(
+            observer,
+            selector: selector,
+            name: event.notification,
+            object: nil
+        )
+    }
+
+    public func removeHandler(observer: Any, event: ProviderEvent) {
+        providerNotificationCentre.removeObserver(observer, name: event.notification, object: nil)
+    }
+
+    public func emit(
+        _ event: ProviderEvent,
+        provider: FeatureProvider,
+        error: Error? = nil,
+        details: [AnyHashable: Any]? = nil
+    ) {
+        var userInfo: [AnyHashable: Any] = [:]
+        userInfo[providerEventDetailsKeyProvider] = provider
+
+        if let error {
+            userInfo[providerEventDetailsKeyError] = error
+        }
+
+        if let details {
+            userInfo.merge(details) { $1 } // Merge, keeping value from `details` if any conflicts
+        }
+
+        providerNotificationCentre.post(name: event.notification, object: nil, userInfo: userInfo)
+    }
+}
+
+public protocol EventPublisher {
+    func addHandler(observer: Any, selector: Selector, event: ProviderEvent)
+    func removeHandler(observer: Any, event: ProviderEvent)
+}
+
+public protocol EventEmitter {
+    func emit(_ event: ProviderEvent, provider: FeatureProvider, error: Error?, details: [AnyHashable: Any]?)
+}

--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -73,11 +73,19 @@ public class OpenFeatureAPI {
         self.hooks.removeAll()
     }
 
-    public func observe() -> any Publisher<ProviderEvent, Never> {
+    public func observe() -> AnyPublisher<ProviderEvent, Never> {
         return providerSubject
-            .compactMap{ $0 }
-            .map({ provider in provider.observe()})
+            .map({ provider in
+                if let provider = provider {
+                    return provider.observe()
+                } else {
+                    return Empty<ProviderEvent, Never>()
+                        .eraseToAnyPublisher()
+                }
+            })
             .switchToLatest()
+            .eraseToAnyPublisher()
+
     }
 
     struct Handler {

--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -7,8 +7,6 @@ public class OpenFeatureAPI {
     private var _context: EvaluationContext?
     private(set) var hooks: [any Hook] = []
 
-    private let providerNotificationCentre = NotificationCenter()
-
     /// The ``OpenFeatureAPI`` singleton
     static public let shared = OpenFeatureAPI()
 
@@ -64,42 +62,5 @@ public class OpenFeatureAPI {
 
     public func clearHooks() {
         self.hooks.removeAll()
-    }
-}
-
-// MARK: Provider Events
-
-extension OpenFeatureAPI {
-    public func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
-        providerNotificationCentre.addObserver(
-            observer,
-            selector: selector,
-            name: event.notification,
-            object: nil
-        )
-    }
-
-    public func removeHandler(observer: Any, event: ProviderEvent) {
-        providerNotificationCentre.removeObserver(observer, name: event.notification, object: nil)
-    }
-
-    public func emitEvent(
-        _ event: ProviderEvent,
-        provider: FeatureProvider,
-        error: Error? = nil,
-        details: [AnyHashable: Any]? = nil
-    ) {
-        var userInfo: [AnyHashable: Any] = [:]
-        userInfo[providerEventDetailsKeyProvider] = provider
-
-        if let error {
-            userInfo[providerEventDetailsKeyError] = error
-        }
-
-        if let details {
-            userInfo.merge(details) { $1 } // Merge, keeping value from `details` if any conflicts
-        }
-
-        providerNotificationCentre.post(name: event.notification, object: nil, userInfo: userInfo)
     }
 }

--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -5,12 +5,11 @@ import Combine
 /// Configuration here will be shared across all ``Client``s.
 public class OpenFeatureAPI {
     private var _provider: FeatureProvider? {
-        set {
-            providerSubject.send(newValue)
-        }
-
         get {
             providerSubject.value
+        }
+        set {
+            providerSubject.send(newValue)
         }
     }
     private var _context: EvaluationContext?
@@ -74,18 +73,16 @@ public class OpenFeatureAPI {
     }
 
     public func observe() -> AnyPublisher<ProviderEvent, Never> {
-        return providerSubject
-            .map({ provider in
-                if let provider = provider {
-                    return provider.observe()
-                } else {
-                    return Empty<ProviderEvent, Never>()
-                        .eraseToAnyPublisher()
-                }
-            })
-            .switchToLatest()
-            .eraseToAnyPublisher()
-
+        return providerSubject.map { provider in
+            if let provider = provider {
+                return provider.observe()
+            } else {
+                return Empty<ProviderEvent, Never>()
+                    .eraseToAnyPublisher()
+            }
+        }
+        .switchToLatest()
+        .eraseToAnyPublisher()
     }
 
     struct Handler {

--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -75,8 +75,8 @@ public class OpenFeatureAPI {
 
     public func observe() -> any Publisher<ProviderEvent, Never> {
         return providerSubject
-            .filter({provider in provider != nil})
-            .map({ provider in provider!.observe()})
+            .compactMap{ $0 }
+            .map({ provider in provider.observe()})
             .switchToLatest()
     }
 

--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -84,10 +84,4 @@ public class OpenFeatureAPI {
         .switchToLatest()
         .eraseToAnyPublisher()
     }
-
-    struct Handler {
-        let observer: Any
-        let selector: Selector
-        let event: ProviderEvent
-    }
 }

--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 /// A global singleton which holds base configuration for the OpenFeature library.
 /// Configuration here will be shared across all ``Client``s.
@@ -22,10 +23,6 @@ public class OpenFeatureAPI: EventPublisher {
         self._provider = provider
         if let context = initialContext {
             self._context = context
-        }
-
-        handlers.forEach { handler in
-            provider.addHandler(observer: handler.observer, selector: handler.selector, event: handler.event)
         }
         provider.initialize(initialContext: self._context)
     }
@@ -68,15 +65,8 @@ public class OpenFeatureAPI: EventPublisher {
         self.hooks.removeAll()
     }
 
-    public func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
-        handlers.append(Handler(observer: observer, selector: selector, event: event))
-        // TODO If a provider is already set, the handler should receive an event for the current status according to specs
-        getProvider()?.addHandler(observer: observer, selector: selector, event: event)
-    }
-
-    public func removeHandler(observer: Any, event: ProviderEvent) {
-        // TODO remove in local 'handlers' arrays
-        getProvider()?.removeHandler(observer: observer, event: event)
+    public func observe() -> Publishers.MergeMany<NotificationCenter.Publisher> {
+        getProvider()!.observe() // TODO Fix!
     }
 
     struct Handler {

--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -65,7 +65,7 @@ public class OpenFeatureAPI: EventPublisher {
         self.hooks.removeAll()
     }
 
-    public func observe() -> Publishers.MergeMany<NotificationCenter.Publisher> {
+    public func observe() -> CurrentValueSubject<ProviderEvent, Never> {
         getProvider()!.observe() // TODO Fix!
     }
 

--- a/Sources/OpenFeature/OpenFeatureClient.swift
+++ b/Sources/OpenFeature/OpenFeatureClient.swift
@@ -14,15 +14,11 @@ public class OpenFeatureClient: Client {
     private var hookSupport = HookSupport()
     private var logger = Logger()
 
-    private let providerNotificationCentre = NotificationCenter()
-
     public init(openFeatureApi: OpenFeatureAPI, name: String?, version: String?) {
         self.openFeatureApi = openFeatureApi
         self.name = name
         self.version = version
         self.metadata = Metadata(name: name)
-
-        subscribeToAllProviderEvents()
     }
 
     public func addHooks(_ hooks: any Hook...) {
@@ -198,44 +194,5 @@ extension OpenFeatureClient {
         }
 
         throw OpenFeatureError.generalError(message: "Unable to match default value type with flag value type")
-    }
-}
-
-// MARK: Events
-
-extension OpenFeatureClient {
-    public func subscribeToAllProviderEvents() {
-        ProviderEvent.allCases.forEach { event in
-            OpenFeatureAPI.shared.addHandler(
-                observer: self,
-                selector: #selector(handleProviderEvent(notification:)),
-                event: event)
-        }
-    }
-
-    public func unsubscribeFromAllProviderEvents() {
-        ProviderEvent.allCases.forEach { event in
-            OpenFeatureAPI.shared.removeHandler(observer: self, event: event)
-        }
-    }
-
-    @objc public func handleProviderEvent(notification: Notification) {
-        var userInfo: [AnyHashable: Any] = notification.userInfo ?? [:]
-        userInfo[providerEventDetailsKeyClient] = self
-
-        providerNotificationCentre.post(name: notification.name, object: nil, userInfo: userInfo)
-    }
-
-    public func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
-        providerNotificationCentre.addObserver(
-            observer,
-            selector: selector,
-            name: event.notification,
-            object: nil
-        )
-    }
-
-    public func removeHandler(observer: Any, event: ProviderEvent) {
-        providerNotificationCentre.removeObserver(observer, name: event.notification, object: nil)
     }
 }

--- a/Sources/OpenFeature/Provider/FeatureProvider.swift
+++ b/Sources/OpenFeature/Provider/FeatureProvider.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// The interface implemented by upstream flag providers to resolve flags for their service.
-public protocol FeatureProvider {
+public protocol FeatureProvider: EventPublisher {
     var hooks: [any Hook] { get }
     var metadata: ProviderMetadata { get }
 

--- a/Sources/OpenFeature/Provider/NoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/NoOpProvider.swift
@@ -15,11 +15,11 @@ class NoOpProvider: FeatureProvider {
     var hooks: [any Hook] = []
 
     func onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        eventHandler.emit(.configurationChanged)
+        eventHandler.send(.configurationChanged)
     }
 
     func initialize(initialContext: EvaluationContext?) {
-        eventHandler.emit(.ready)
+        eventHandler.send(.ready)
     }
 
     func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws

--- a/Sources/OpenFeature/Provider/NoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/NoOpProvider.swift
@@ -67,7 +67,7 @@ class NoOpProvider: FeatureProvider {
             value: defaultValue, variant: NoOpProvider.passedInDefault, reason: Reason.defaultReason.rawValue)
     }
 
-    func observe() -> CurrentValueSubject<ProviderEvent, Never> {
+    func observe() -> AnyPublisher<ProviderEvent, Never> {
         return eventHandler.observe()
     }
 }

--- a/Sources/OpenFeature/Provider/NoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/NoOpProvider.swift
@@ -4,7 +4,7 @@ import Combine
 /// A ``FeatureProvider`` that simply returns the default values passed to it.
 class NoOpProvider: FeatureProvider {
     public static let passedInDefault = "Passed in default"
-    private let eventHandler = EventHandler()
+    private let eventHandler = EventHandler(.ready)
 
     public enum Mode {
         case normal
@@ -15,11 +15,11 @@ class NoOpProvider: FeatureProvider {
     var hooks: [any Hook] = []
 
     func onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        eventHandler.emit(.configurationChanged, provider: self)
+        eventHandler.emit(.configurationChanged)
     }
 
     func initialize(initialContext: EvaluationContext?) {
-        eventHandler.emit(.ready, provider: self)
+        eventHandler.emit(.ready)
     }
 
     func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
@@ -67,7 +67,7 @@ class NoOpProvider: FeatureProvider {
             value: defaultValue, variant: NoOpProvider.passedInDefault, reason: Reason.defaultReason.rawValue)
     }
 
-    func observe() -> Publishers.MergeMany<NotificationCenter.Publisher> {
+    func observe() -> CurrentValueSubject<ProviderEvent, Never> {
         return eventHandler.observe()
     }
 }

--- a/Sources/OpenFeature/Provider/NoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/NoOpProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 /// A ``FeatureProvider`` that simply returns the default values passed to it.
 class NoOpProvider: FeatureProvider {
@@ -66,12 +67,8 @@ class NoOpProvider: FeatureProvider {
             value: defaultValue, variant: NoOpProvider.passedInDefault, reason: Reason.defaultReason.rawValue)
     }
 
-    func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
-        eventHandler.addHandler(observer: observer, selector: selector, event: event)
-    }
-
-    func removeHandler(observer: Any, event: ProviderEvent) {
-        eventHandler.removeHandler(observer: observer, event: event)
+    func observe() -> Publishers.MergeMany<NotificationCenter.Publisher> {
+        return eventHandler.observe()
     }
 }
 

--- a/Sources/OpenFeature/Provider/NoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/NoOpProvider.swift
@@ -15,7 +15,7 @@ class NoOpProvider: FeatureProvider {
     var hooks: [any Hook] = []
 
     func onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        eventHandler.send(.configurationChanged)
+        eventHandler.send(.ready)
     }
 
     func initialize(initialContext: EvaluationContext?) {

--- a/Sources/OpenFeature/Provider/NoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/NoOpProvider.swift
@@ -3,6 +3,7 @@ import Foundation
 /// A ``FeatureProvider`` that simply returns the default values passed to it.
 class NoOpProvider: FeatureProvider {
     public static let passedInDefault = "Passed in default"
+    private let eventHandler = EventHandler()
 
     public enum Mode {
         case normal
@@ -13,11 +14,11 @@ class NoOpProvider: FeatureProvider {
     var hooks: [any Hook] = []
 
     func onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext) {
-        OpenFeatureAPI.shared.emitEvent(.configurationChanged, provider: self)
+        eventHandler.emit(.configurationChanged, provider: self)
     }
 
     func initialize(initialContext: EvaluationContext?) {
-        OpenFeatureAPI.shared.emitEvent(.ready, provider: self)
+        eventHandler.emit(.ready, provider: self)
     }
 
     func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
@@ -63,6 +64,14 @@ class NoOpProvider: FeatureProvider {
     {
         return ProviderEvaluation(
             value: defaultValue, variant: NoOpProvider.passedInDefault, reason: Reason.defaultReason.rawValue)
+    }
+
+    func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
+        eventHandler.addHandler(observer: observer, selector: selector, event: event)
+    }
+
+    func removeHandler(observer: Any, event: ProviderEvent) {
+        eventHandler.removeHandler(observer: observer, event: event)
     }
 }
 

--- a/Sources/OpenFeature/Provider/ProviderEvents.swift
+++ b/Sources/OpenFeature/Provider/ProviderEvents.swift
@@ -10,7 +10,7 @@ public enum ProviderEvent: String, CaseIterable {
     case configurationChanged = "PROVIDER_CONFIGURATION_CHANGED"
     case stale = "PROVIDER_STALE"
 
-    var notification: NSNotification.Name {
+    public var notificationName: NSNotification.Name {
         NSNotification.Name(rawValue)
     }
 }

--- a/Sources/OpenFeature/Provider/ProviderEvents.swift
+++ b/Sources/OpenFeature/Provider/ProviderEvents.swift
@@ -9,8 +9,4 @@ public enum ProviderEvent: String, CaseIterable {
     case error = "PROVIDER_ERROR"
     case configurationChanged = "PROVIDER_CONFIGURATION_CHANGED"
     case stale = "PROVIDER_STALE"
-
-    public var notificationName: NSNotification.Name {
-        NSNotification.Name(rawValue)
-    }
 }

--- a/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
+++ b/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
@@ -39,11 +39,13 @@ final class DeveloperExperienceTests: XCTestCase {
         OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
 
+        OpenFeatureAPI.shared.clearProvider()
+
         // Clearing the Provider shouldn't send further global events from it
         eventState = OpenFeatureAPI.shared.observe().sink { _ in
             XCTFail("Unexpected event")
         }
-        OpenFeatureAPI.shared.clearProvider()
+
         provider.initialize(initialContext: MutableContext(attributes: ["Test": Value.string("Test")]))
 
         XCTAssertNotNil(eventState)

--- a/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
+++ b/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
@@ -19,6 +19,22 @@ final class DeveloperExperienceTests: XCTestCase {
         XCTAssertFalse(flagValue)
     }
 
+    func testObserveProviderReady() {
+        OpenFeatureAPI.shared.addHandler(
+            observer: self,
+            selector: #selector(readyEventEmitted(notification:)),
+            event: .ready)
+        OpenFeatureAPI.shared.setProvider(provider: DoSomethingProvider())
+        wait(for: [readyExpectation], timeout: 5)
+    }
+
+    // MARK: Event Handlers
+    let readyExpectation = XCTestExpectation(description: "Ready")
+
+    func readyEventEmitted(notification: NSNotification) {
+        readyExpectation.fulfill()
+    }
+
     func testClientHooks() {
         OpenFeatureAPI.shared.setProvider(provider: NoOpProvider())
         let client = OpenFeatureAPI.shared.getClient()

--- a/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
+++ b/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
@@ -3,6 +3,8 @@ import XCTest
 @testable import OpenFeature
 
 final class DeveloperExperienceTests: XCTestCase {
+    let readyExpectation = XCTestExpectation(description: "Ready")
+
     func testNoProviderSet() {
         OpenFeatureAPI.shared.clearProvider()
         let client = OpenFeatureAPI.shared.getClient()
@@ -19,21 +21,19 @@ final class DeveloperExperienceTests: XCTestCase {
         XCTAssertFalse(flagValue)
     }
 
-    func testObserveProviderReady() {
-        OpenFeatureAPI.shared.addHandler(
-            observer: self,
-            selector: #selector(readyEventEmitted(notification:)),
-            event: .ready)
-        OpenFeatureAPI.shared.setProvider(provider: DoSomethingProvider())
-        wait(for: [readyExpectation], timeout: 5)
-    }
-
-    // MARK: Event Handlers
-    let readyExpectation = XCTestExpectation(description: "Ready")
-
-    func readyEventEmitted(notification: NSNotification) {
-        readyExpectation.fulfill()
-    }
+//    func testObserveProviderReady() {
+//        let cancellable = OpenFeatureAPI.shared.observe().sink { notification in
+//            switch notification.name {
+//            case ProviderEvent.ready.notificationName:
+//                self.readyExpectation.fulfill()
+//            default:
+//                XCTFail("Unexpected event")
+//            }
+//        }
+//        OpenFeatureAPI.shared.setProvider(provider: DoSomethingProvider())
+//        wait(for: [readyExpectation], timeout: 5)
+//        XCTAssertNotNil(cancellable)
+//    }
 
     func testClientHooks() {
         OpenFeatureAPI.shared.setProvider(provider: NoOpProvider())

--- a/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
+++ b/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
@@ -39,15 +39,13 @@ final class DeveloperExperienceTests: XCTestCase {
         OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
 
-        OpenFeatureAPI.shared.clearProvider()
-
         // Clearing the Provider shouldn't send further global events from it
-        eventState = OpenFeatureAPI.shared.observe().sink { _ in
+        // Dropping the first event, which reflects the current state before clearing
+        eventState = OpenFeatureAPI.shared.observe().dropFirst().sink { _ in
             XCTFail("Unexpected event")
         }
-
+        OpenFeatureAPI.shared.clearProvider()
         provider.initialize(initialContext: MutableContext(attributes: ["Test": Value.string("Test")]))
-
         XCTAssertNotNil(eventState)
     }
 

--- a/Tests/OpenFeatureTests/FlagEvaluationTests.swift
+++ b/Tests/OpenFeatureTests/FlagEvaluationTests.swift
@@ -6,14 +6,6 @@ import XCTest
 final class FlagEvaluationTests: XCTestCase {
     override func setUp() {
         super.setUp()
-
-        OpenFeatureAPI.shared.addHandler(
-            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
-        )
-
-        OpenFeatureAPI.shared.addHandler(
-            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
-        )
     }
 
     func testSingletonPersists() {
@@ -23,7 +15,6 @@ final class FlagEvaluationTests: XCTestCase {
     func testApiSetsProvider() {
         let provider = NoOpProvider()
         OpenFeatureAPI.shared.setProvider(provider: provider)
-
         XCTAssertTrue((OpenFeatureAPI.shared.getProvider() as? NoOpProvider) === provider)
     }
 
@@ -64,7 +55,15 @@ final class FlagEvaluationTests: XCTestCase {
     }
 
     func testSimpleFlagEvaluation() {
-        OpenFeatureAPI.shared.setProvider(provider: DoSomethingProvider())
+        let provider = DoSomethingProvider()
+        provider.addHandler(
+            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
+        )
+
+        provider.addHandler(
+            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
+        )
+        OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
 
         let client = OpenFeatureAPI.shared.getClient()
@@ -103,7 +102,15 @@ final class FlagEvaluationTests: XCTestCase {
     }
 
     func testDetailedFlagEvaluation() async {
-        OpenFeatureAPI.shared.setProvider(provider: DoSomethingProvider())
+        let provider = DoSomethingProvider()
+        provider.addHandler(
+            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
+        )
+
+        provider.addHandler(
+            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
+        )
+        OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
 
         let client = OpenFeatureAPI.shared.getClient()
@@ -148,7 +155,15 @@ final class FlagEvaluationTests: XCTestCase {
     }
 
     func testHooksAreFired() async {
-        OpenFeatureAPI.shared.setProvider(provider: NoOpProvider())
+        let provider = NoOpProvider()
+        provider.addHandler(
+            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
+        )
+
+        provider.addHandler(
+            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
+        )
+        OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
 
         let client = OpenFeatureAPI.shared.getClient()
@@ -167,7 +182,15 @@ final class FlagEvaluationTests: XCTestCase {
     }
 
     func testBrokenProvider() {
-        OpenFeatureAPI.shared.setProvider(provider: AlwaysBrokenProvider())
+        let provider = AlwaysBrokenProvider()
+        provider.addHandler(
+            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
+        )
+
+        provider.addHandler(
+            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
+        )
+        OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [errorExpectation], timeout: 5)
 
         let client = OpenFeatureAPI.shared.getClient()

--- a/Tests/OpenFeatureTests/FlagEvaluationTests.swift
+++ b/Tests/OpenFeatureTests/FlagEvaluationTests.swift
@@ -60,7 +60,7 @@ final class FlagEvaluationTests: XCTestCase {
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
-        let subject = provider.observe().sink { event in
+        let eventState = provider.observe().sink { event in
             switch event {
             case ProviderEvent.ready:
                 readyExpectation.fulfill()
@@ -108,7 +108,7 @@ final class FlagEvaluationTests: XCTestCase {
         XCTAssertEqual(value, .null)
         value = client.getValue(key: key, defaultValue: .structure([:]), options: FlagEvaluationOptions())
         XCTAssertEqual(value, .null)
-        XCTAssertNotNil(subject)
+        XCTAssertNotNil(eventState)
     }
 
     func testDetailedFlagEvaluation() async {
@@ -116,7 +116,7 @@ final class FlagEvaluationTests: XCTestCase {
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
-        let subject = provider.observe().sink { event in
+        let eventState = provider.observe().sink { event in
             switch event {
             case ProviderEvent.ready:
                 readyExpectation.fulfill()
@@ -169,7 +169,7 @@ final class FlagEvaluationTests: XCTestCase {
             client.getDetails(
                 key: key, defaultValue: .structure([:]), options: FlagEvaluationOptions()),
             objectDetails)
-        XCTAssertNotNil(subject)
+        XCTAssertNotNil(eventState)
     }
 
     func testHooksAreFired() async {
@@ -177,7 +177,7 @@ final class FlagEvaluationTests: XCTestCase {
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
-        let subject = provider.observe().sink { event in
+        let eventState = provider.observe().sink { event in
             switch event {
             case ProviderEvent.ready:
                 readyExpectation.fulfill()
@@ -206,7 +206,7 @@ final class FlagEvaluationTests: XCTestCase {
 
         XCTAssertEqual(clientHook.beforeCalled, 1)
         XCTAssertEqual(invocationHook.beforeCalled, 1)
-        XCTAssertNotNil(subject)
+        XCTAssertNotNil(eventState)
     }
 
     func testBrokenProvider() {
@@ -214,7 +214,7 @@ final class FlagEvaluationTests: XCTestCase {
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
-        let subject = provider.observe().sink { event in
+        let eventState = provider.observe().sink { event in
             switch event {
             case ProviderEvent.ready:
                 readyExpectation.fulfill()
@@ -237,7 +237,7 @@ final class FlagEvaluationTests: XCTestCase {
         XCTAssertEqual(details.errorCode, .flagNotFound)
         XCTAssertEqual(details.reason, Reason.error.rawValue)
         XCTAssertEqual(details.errorMessage, "Could not find flag for key: testkey")
-        XCTAssertNotNil(subject)
+        XCTAssertNotNil(eventState)
     }
 
     func testClientMetadata() {

--- a/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
@@ -5,15 +5,16 @@ import Foundation
 class AlwaysBrokenProvider: FeatureProvider {
     var metadata: ProviderMetadata = AlwaysBrokenMetadata()
     var hooks: [any Hook] = []
+    private let eventHandler = EventHandler()
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
         let error = OpenFeatureError.generalError(message: "Always Fails")
-        OpenFeatureAPI.shared.emitEvent(.error, provider: self, error: error)
+        eventHandler.emit(.error, provider: self, error: error)
     }
 
     func initialize(initialContext: OpenFeature.EvaluationContext?) {
         let error = OpenFeatureError.generalError(message: "Always Fails")
-        OpenFeatureAPI.shared.emitEvent(.error, provider: self, error: error)
+        eventHandler.emit(.error, provider: self, error: error)
     }
 
     func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
@@ -44,6 +45,14 @@ class AlwaysBrokenProvider: FeatureProvider {
         -> OpenFeature.ProviderEvaluation<OpenFeature.Value>
     {
         throw OpenFeatureError.flagNotFoundError(key: key)
+    }
+
+    func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
+        eventHandler.addHandler(observer: observer, selector: selector, event: event)
+    }
+
+    func removeHandler(observer: Any, event: ProviderEvent) {
+        eventHandler.removeHandler(observer: observer, event: event)
     }
 }
 

--- a/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
@@ -1,4 +1,5 @@
 import Foundation
+import Combine
 
 @testable import OpenFeature
 
@@ -47,12 +48,8 @@ class AlwaysBrokenProvider: FeatureProvider {
         throw OpenFeatureError.flagNotFoundError(key: key)
     }
 
-    func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
-        eventHandler.addHandler(observer: observer, selector: selector, event: event)
-    }
-
-    func removeHandler(observer: Any, event: ProviderEvent) {
-        eventHandler.removeHandler(observer: observer, event: event)
+    func observe() -> Publishers.MergeMany<NotificationCenter.Publisher> {
+        eventHandler.observe()
     }
 }
 

--- a/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
@@ -46,7 +46,7 @@ class AlwaysBrokenProvider: FeatureProvider {
         throw OpenFeatureError.flagNotFoundError(key: key)
     }
 
-    func observe() -> CurrentValueSubject<ProviderEvent, Never> {
+    func observe() -> AnyPublisher<ProviderEvent, Never> {
         eventHandler.observe()
     }
 }

--- a/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
@@ -6,16 +6,16 @@ import Combine
 class AlwaysBrokenProvider: FeatureProvider {
     var metadata: ProviderMetadata = AlwaysBrokenMetadata()
     var hooks: [any Hook] = []
-    private let eventHandler = EventHandler()
+    private let eventHandler = EventHandler(.stale)
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
         let error = OpenFeatureError.generalError(message: "Always Fails")
-        eventHandler.emit(.error, provider: self, error: error)
+        eventHandler.emit(.error)
     }
 
     func initialize(initialContext: OpenFeature.EvaluationContext?) {
         let error = OpenFeatureError.generalError(message: "Always Fails")
-        eventHandler.emit(.error, provider: self, error: error)
+        eventHandler.emit(.error)
     }
 
     func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
@@ -48,7 +48,7 @@ class AlwaysBrokenProvider: FeatureProvider {
         throw OpenFeatureError.flagNotFoundError(key: key)
     }
 
-    func observe() -> Publishers.MergeMany<NotificationCenter.Publisher> {
+    func observe() -> CurrentValueSubject<ProviderEvent, Never> {
         eventHandler.observe()
     }
 }

--- a/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
@@ -9,13 +9,11 @@ class AlwaysBrokenProvider: FeatureProvider {
     private let eventHandler = EventHandler(.stale)
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
-        let error = OpenFeatureError.generalError(message: "Always Fails")
-        eventHandler.emit(.error)
+        eventHandler.send(.error)
     }
 
     func initialize(initialContext: OpenFeature.EvaluationContext?) {
-        let error = OpenFeatureError.generalError(message: "Always Fails")
-        eventHandler.emit(.error)
+        eventHandler.send(.error)
     }
 
     func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws

--- a/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
@@ -8,7 +8,7 @@ class DoSomethingProvider: FeatureProvider {
     private var holdit: AnyCancellable?
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
-        eventHandler.send(.configurationChanged)
+        eventHandler.send(.ready)
     }
 
     func initialize(initialContext: OpenFeature.EvaluationContext?) {

--- a/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
@@ -8,11 +8,11 @@ class DoSomethingProvider: FeatureProvider {
     private var holdit: AnyCancellable?
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
-        eventHandler.emit(.configurationChanged)
+        eventHandler.send(.configurationChanged)
     }
 
     func initialize(initialContext: OpenFeature.EvaluationContext?) {
-        eventHandler.emit(.ready)
+        eventHandler.send(.ready)
     }
 
     var hooks: [any OpenFeature.Hook] = []

--- a/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
@@ -58,7 +58,7 @@ class DoSomethingProvider: FeatureProvider {
         return ProviderEvaluation(value: .null)
     }
 
-    func observe() -> CurrentValueSubject<ProviderEvent, Never> {
+    func observe() -> AnyPublisher<ProviderEvent, Never> {
         eventHandler.observe()
     }
 

--- a/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
@@ -4,15 +4,15 @@ import Combine
 
 class DoSomethingProvider: FeatureProvider {
     public static let name = "Something"
-    private let eventHandler = EventHandler()
+    private let eventHandler = EventHandler(.ready)
     private var holdit: AnyCancellable?
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
-        eventHandler.emit(.configurationChanged, provider: self)
+        eventHandler.emit(.configurationChanged)
     }
 
     func initialize(initialContext: OpenFeature.EvaluationContext?) {
-        eventHandler.emit(.ready, provider: self)
+        eventHandler.emit(.ready)
     }
 
     var hooks: [any OpenFeature.Hook] = []
@@ -58,7 +58,7 @@ class DoSomethingProvider: FeatureProvider {
         return ProviderEvaluation(value: .null)
     }
 
-    func observe() -> Publishers.MergeMany<NotificationCenter.Publisher> {
+    func observe() -> CurrentValueSubject<ProviderEvent, Never> {
         eventHandler.observe()
     }
 

--- a/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
@@ -1,9 +1,11 @@
 import Foundation
 import OpenFeature
+import Combine
 
 class DoSomethingProvider: FeatureProvider {
     public static let name = "Something"
     private let eventHandler = EventHandler()
+    private var holdit: AnyCancellable?
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
         eventHandler.emit(.configurationChanged, provider: self)
@@ -56,12 +58,8 @@ class DoSomethingProvider: FeatureProvider {
         return ProviderEvaluation(value: .null)
     }
 
-    func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
-        eventHandler.addHandler(observer: observer, selector: selector, event: event)
-    }
-
-    func removeHandler(observer: Any, event: ProviderEvent) {
-        eventHandler.removeHandler(observer: observer, event: event)
+    func observe() -> Publishers.MergeMany<NotificationCenter.Publisher> {
+        eventHandler.observe()
     }
 
     public struct DoMetadata: ProviderMetadata {

--- a/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
@@ -3,13 +3,14 @@ import OpenFeature
 
 class DoSomethingProvider: FeatureProvider {
     public static let name = "Something"
+    private let eventHandler = EventHandler()
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
-        OpenFeatureAPI.shared.emitEvent(.configurationChanged, provider: self)
+        eventHandler.emit(.configurationChanged, provider: self)
     }
 
     func initialize(initialContext: OpenFeature.EvaluationContext?) {
-        OpenFeatureAPI.shared.emitEvent(.ready, provider: self)
+        eventHandler.emit(.ready, provider: self)
     }
 
     var hooks: [any OpenFeature.Hook] = []
@@ -53,6 +54,14 @@ class DoSomethingProvider: FeatureProvider {
         >
     {
         return ProviderEvaluation(value: .null)
+    }
+
+    func addHandler(observer: Any, selector: Selector, event: ProviderEvent) {
+        eventHandler.addHandler(observer: observer, selector: selector, event: event)
+    }
+
+    func removeHandler(observer: Any, event: ProviderEvent) {
+        eventHandler.removeHandler(observer: observer, event: event)
     }
 
     public struct DoMetadata: ProviderMetadata {

--- a/Tests/OpenFeatureTests/HookSpecTests.swift
+++ b/Tests/OpenFeatureTests/HookSpecTests.swift
@@ -13,7 +13,7 @@ final class HookSpecTests: XCTestCase {
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
-        let subject = provider.observe().sink { event in
+        let eventState = provider.observe().sink { event in
             switch event {
             case ProviderEvent.ready:
                 readyExpectation.fulfill()
@@ -41,7 +41,7 @@ final class HookSpecTests: XCTestCase {
         XCTAssertEqual(hook.afterCalled, 1)
         XCTAssertEqual(hook.errorCalled, 0)
         XCTAssertEqual(hook.finallyAfterCalled, 1)
-        XCTAssertNotNil(subject)
+        XCTAssertNotNil(eventState)
     }
 
     func testErrorHookButNoAfterCalled() {
@@ -49,7 +49,7 @@ final class HookSpecTests: XCTestCase {
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
-        let subject = provider.observe().sink { event in
+        let eventState = provider.observe().sink { event in
             switch event {
             case ProviderEvent.ready:
                 readyExpectation.fulfill()
@@ -76,7 +76,7 @@ final class HookSpecTests: XCTestCase {
         XCTAssertEqual(hook.afterCalled, 0)
         XCTAssertEqual(hook.errorCalled, 1)
         XCTAssertEqual(hook.finallyAfterCalled, 1)
-        XCTAssertNotNil(subject)
+        XCTAssertNotNil(eventState)
     }
 
     func testHookEvaluationOrder() {
@@ -91,7 +91,7 @@ final class HookSpecTests: XCTestCase {
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
-        let subject = providerMock.observe().sink { event in
+        let eventState = providerMock.observe().sink { event in
             switch event {
             case ProviderEvent.ready:
                 readyExpectation.fulfill()
@@ -131,7 +131,7 @@ final class HookSpecTests: XCTestCase {
                 "client finallyAfter",
                 "api finallyAfter",
             ])
-        XCTAssertNotNil(subject)
+        XCTAssertNotNil(eventState)
     }
 }
 

--- a/Tests/OpenFeatureTests/HookSpecTests.swift
+++ b/Tests/OpenFeatureTests/HookSpecTests.swift
@@ -6,18 +6,18 @@ import XCTest
 final class HookSpecTests: XCTestCase {
     override func setUp() {
         super.setUp()
-
-        OpenFeatureAPI.shared.addHandler(
-            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
-        )
-
-        OpenFeatureAPI.shared.addHandler(
-            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
-        )
     }
 
     func testNoErrorHookCalled() {
-        OpenFeatureAPI.shared.setProvider(provider: NoOpProvider())
+        let provider = NoOpProvider()
+        provider.addHandler(
+            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
+        )
+
+        provider.addHandler(
+            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
+        )
+        OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
 
         let client = OpenFeatureAPI.shared.getClient()
@@ -36,7 +36,15 @@ final class HookSpecTests: XCTestCase {
     }
 
     func testErrorHookButNoAfterCalled() {
-        OpenFeatureAPI.shared.setProvider(provider: AlwaysBrokenProvider())
+        let provider = AlwaysBrokenProvider()
+        provider.addHandler(
+            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
+        )
+
+        provider.addHandler(
+            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
+        )
+        OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [errorExpectation], timeout: 5)
 
         let client = OpenFeatureAPI.shared.getClient()
@@ -62,6 +70,13 @@ final class HookSpecTests: XCTestCase {
         let providerMock = NoOpProviderMock(hooks: [
             BooleanHookMock(prefix: "provider", addEval: addEval)
         ])
+        providerMock.addHandler(
+            observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
+        )
+
+        providerMock.addHandler(
+            observer: self, selector: #selector(errorEventEmitted(notification:)), event: .error
+        )
         OpenFeatureAPI.shared.setProvider(provider: providerMock)
         wait(for: [readyExpectation], timeout: 5)
 

--- a/Tests/OpenFeatureTests/HookSpecTests.swift
+++ b/Tests/OpenFeatureTests/HookSpecTests.swift
@@ -10,12 +10,17 @@ final class HookSpecTests: XCTestCase {
 
     func testNoErrorHookCalled() {
         let provider = NoOpProvider()
-        let cancellable = provider.observe().sink { notification in
-            switch notification.name {
-            case ProviderEvent.ready.notificationName:
-                self.readyExpectation.fulfill()
-            case ProviderEvent.error.notificationName:
-                self.errorExpectation.fulfill()
+        let readyExpectation = XCTestExpectation(description: "Ready")
+        let errorExpectation = XCTestExpectation(description: "Error")
+        let staleExpectation = XCTestExpectation(description: "Stale")
+        let subject = provider.observe().sink { event in
+            switch event {
+            case ProviderEvent.ready:
+                readyExpectation.fulfill()
+            case ProviderEvent.error:
+                errorExpectation.fulfill()
+            case ProviderEvent.stale:
+                staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }
@@ -36,17 +41,22 @@ final class HookSpecTests: XCTestCase {
         XCTAssertEqual(hook.afterCalled, 1)
         XCTAssertEqual(hook.errorCalled, 0)
         XCTAssertEqual(hook.finallyAfterCalled, 1)
-        XCTAssertNotNil(cancellable)
+        XCTAssertNotNil(subject)
     }
 
     func testErrorHookButNoAfterCalled() {
         let provider = AlwaysBrokenProvider()
-        let cancellable = provider.observe().sink { notification in
-            switch notification.name {
-            case ProviderEvent.ready.notificationName:
-                self.readyExpectation.fulfill()
-            case ProviderEvent.error.notificationName:
-                self.errorExpectation.fulfill()
+        let readyExpectation = XCTestExpectation(description: "Ready")
+        let errorExpectation = XCTestExpectation(description: "Error")
+        let staleExpectation = XCTestExpectation(description: "Stale")
+        let subject = provider.observe().sink { event in
+            switch event {
+            case ProviderEvent.ready:
+                readyExpectation.fulfill()
+            case ProviderEvent.error:
+                errorExpectation.fulfill()
+            case ProviderEvent.stale:
+                staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }
@@ -66,7 +76,7 @@ final class HookSpecTests: XCTestCase {
         XCTAssertEqual(hook.afterCalled, 0)
         XCTAssertEqual(hook.errorCalled, 1)
         XCTAssertEqual(hook.finallyAfterCalled, 1)
-        XCTAssertNotNil(cancellable)
+        XCTAssertNotNil(subject)
     }
 
     func testHookEvaluationOrder() {
@@ -78,12 +88,17 @@ final class HookSpecTests: XCTestCase {
         let providerMock = NoOpProviderMock(hooks: [
             BooleanHookMock(prefix: "provider", addEval: addEval)
         ])
-        let cancellable = providerMock.observe().sink { notification in
-            switch notification.name {
-            case ProviderEvent.ready.notificationName:
-                self.readyExpectation.fulfill()
-            case ProviderEvent.error.notificationName:
-                self.errorExpectation.fulfill()
+        let readyExpectation = XCTestExpectation(description: "Ready")
+        let errorExpectation = XCTestExpectation(description: "Error")
+        let staleExpectation = XCTestExpectation(description: "Stale")
+        let subject = providerMock.observe().sink { event in
+            switch event {
+            case ProviderEvent.ready:
+                readyExpectation.fulfill()
+            case ProviderEvent.error:
+                errorExpectation.fulfill()
+            case ProviderEvent.stale:
+                staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }
@@ -116,20 +131,7 @@ final class HookSpecTests: XCTestCase {
                 "client finallyAfter",
                 "api finallyAfter",
             ])
-        XCTAssertNotNil(cancellable)
-    }
-
-    // MARK: Event Handlers
-    let readyExpectation = XCTestExpectation(description: "Ready")
-
-    func readyEventEmitted(notification: NSNotification) {
-        readyExpectation.fulfill()
-    }
-
-    let errorExpectation = XCTestExpectation(description: "Error")
-
-    func errorEventEmitted(notification: NSNotification) {
-        errorExpectation.fulfill()
+        XCTAssertNotNil(subject)
     }
 }
 

--- a/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
@@ -22,25 +22,6 @@ final class OpenFeatureClientTests: XCTestCase {
         XCTAssertEqual(doubleDetails.value, 12_310)
     }
 
-    func testProviderEvents() {
-        setupExpectations()
-
-        let provider = DoSomethingProvider()
-        OpenFeatureAPI.shared.setProvider(provider: provider)
-
-        let client = OpenFeatureAPI.shared.getClient()
-        ProviderEvent.allCases.forEach { event in
-            client.addHandler(observer: self, selector: #selector(eventEmitted(notification:)), event: event)
-
-            OpenFeatureAPI.shared.emitEvent(event, provider: provider)
-            if let expectation = eventExpectations[event] {
-                wait(for: [expectation], timeout: 5)
-            } else {
-                XCTFail("No expectation for provider event: \(event)")
-            }
-        }
-    }
-
     // MARK: Event Handlers
     private var eventExpectations: [ProviderEvent: XCTestExpectation] = [:]
 

--- a/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
@@ -21,27 +21,4 @@ final class OpenFeatureClientTests: XCTestCase {
         let doubleDetails = client.getDetails(key: "key", defaultValue: 123.1)
         XCTAssertEqual(doubleDetails.value, 12_310)
     }
-
-    // MARK: Event Handlers
-    private var eventExpectations: [ProviderEvent: XCTestExpectation] = [:]
-
-    func setupExpectations() {
-        ProviderEvent.allCases.forEach { event in
-            eventExpectations[event] = XCTestExpectation(description: event.rawValue)
-        }
-    }
-
-    func eventEmitted(notification: NSNotification) {
-        guard let providerEvent = ProviderEvent(rawValue: notification.name.rawValue) else {
-            XCTFail("Unexpected provider event: \(notification.name)")
-            return
-        }
-
-        guard let expectation = eventExpectations[providerEvent] else {
-            XCTFail("No expectation for provider event: \(providerEvent)")
-            return
-        }
-
-        expectation.fulfill()
-    }
 }

--- a/Tests/OpenFeatureTests/ProviderEventsTests.swift
+++ b/Tests/OpenFeatureTests/ProviderEventsTests.swift
@@ -6,7 +6,7 @@ final class ProviderEventsTests: XCTestCase {
     let provider = DoSomethingProvider()
     let readyExpectation = XCTestExpectation(description: "Ready")
 
-    func testReadyEventEmitted() {
+    func testReadyEventSent() {
         let sink = provider
             .observe()
             .filter { event in

--- a/Tests/OpenFeatureTests/ProviderEventsTests.swift
+++ b/Tests/OpenFeatureTests/ProviderEventsTests.swift
@@ -9,8 +9,8 @@ final class ProviderEventsTests: XCTestCase {
     func testReadyEventEmitted() {
         let sink = provider
             .observe()
-            .filter { notification in
-                notification.name == ProviderEvent.ready.notificationName
+            .filter { event in
+                event == ProviderEvent.ready
             }
             .sink { _ in
                 self.readyExpectation.fulfill()

--- a/Tests/OpenFeatureTests/ProviderEventsTests.swift
+++ b/Tests/OpenFeatureTests/ProviderEventsTests.swift
@@ -4,19 +4,19 @@ import XCTest
 
 final class ProviderEventsTests: XCTestCase {
     let provider = DoSomethingProvider()
-    let readyExpectation = XCTestExpectation(description: "Ready")
 
     func testReadyEventSent() {
-        let sink = provider
+        let readyExpectation = XCTestExpectation(description: "Ready")
+        let eventState = provider
             .observe()
             .filter { event in
                 event == ProviderEvent.ready
             }
             .sink { _ in
-                self.readyExpectation.fulfill()
+                readyExpectation.fulfill()
             }
         OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
-        XCTAssertNotNil(sink)
+        XCTAssertNotNil(eventState)
     }
 }

--- a/Tests/OpenFeatureTests/ProviderEventsTests.swift
+++ b/Tests/OpenFeatureTests/ProviderEventsTests.swift
@@ -6,7 +6,7 @@ final class ProviderEventsTests: XCTestCase {
     let provider = DoSomethingProvider()
 
     func testReadyEventEmitted() {
-        OpenFeatureAPI.shared.addHandler(
+        provider.addHandler(
             observer: self, selector: #selector(readyEventEmitted(notification:)), event: .ready
         )
 


### PR DESCRIPTION
## This PR
- Removes event APIs at the client level (will be re-introduced when multiple clients/providers are supported)
- Adds an EventHandler implementation that Providers can use to emit events (a `FeatureProvider` now extends the `EventPublisher` protocol)
- Adds **Combine** as the API for eventing

## Notes
Following patterns implemented in the [Kotlin SDK](https://github.com/open-feature/kotlin-sdk/blob/cce8368f090b335b7b29c66479aaebb44c58ca5b/android/src/main/java/dev/openfeature/sdk/events/EventHandler.kt) as much as possible, for consistency

### Follow-up Tasks
- Add `setProviderAndWait` function in OpenFeatureAPI
- Events should contain more metadata than just their type
- Introduce ProviderStatus as an entity separated from ProviderEvent (also for Kotlin) 