### PR TITLE
refactor: withExtendedLifetime for cancellables

### DIFF
--- a/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
+++ b/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
@@ -46,7 +46,7 @@ final class DeveloperExperienceTests: XCTestCase {
         }
         OpenFeatureAPI.shared.clearProvider()
         provider.initialize(initialContext: MutableContext(attributes: ["Test": Value.string("Test")]))
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 
     func testClientHooks() {

--- a/Tests/OpenFeatureTests/FlagEvaluationTests.swift
+++ b/Tests/OpenFeatureTests/FlagEvaluationTests.swift
@@ -104,7 +104,7 @@ final class FlagEvaluationTests: XCTestCase {
         XCTAssertEqual(value, .null)
         value = client.getValue(key: key, defaultValue: .structure([:]), options: FlagEvaluationOptions())
         XCTAssertEqual(value, .null)
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 
     func testDetailedFlagEvaluation() async {
@@ -165,7 +165,7 @@ final class FlagEvaluationTests: XCTestCase {
             client.getDetails(
                 key: key, defaultValue: .structure([:]), options: FlagEvaluationOptions()),
             objectDetails)
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 
     func testHooksAreFired() async {
@@ -202,7 +202,7 @@ final class FlagEvaluationTests: XCTestCase {
 
         XCTAssertEqual(clientHook.beforeCalled, 1)
         XCTAssertEqual(invocationHook.beforeCalled, 1)
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 
     func testBrokenProvider() {
@@ -233,7 +233,7 @@ final class FlagEvaluationTests: XCTestCase {
         XCTAssertEqual(details.errorCode, .flagNotFound)
         XCTAssertEqual(details.reason, Reason.error.rawValue)
         XCTAssertEqual(details.errorMessage, "Could not find flag for key: testkey")
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 
     func testClientMetadata() {

--- a/Tests/OpenFeatureTests/HookSpecTests.swift
+++ b/Tests/OpenFeatureTests/HookSpecTests.swift
@@ -37,7 +37,7 @@ final class HookSpecTests: XCTestCase {
         XCTAssertEqual(hook.afterCalled, 1)
         XCTAssertEqual(hook.errorCalled, 0)
         XCTAssertEqual(hook.finallyAfterCalled, 1)
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 
     func testErrorHookButNoAfterCalled() {
@@ -72,7 +72,7 @@ final class HookSpecTests: XCTestCase {
         XCTAssertEqual(hook.afterCalled, 0)
         XCTAssertEqual(hook.errorCalled, 1)
         XCTAssertEqual(hook.finallyAfterCalled, 1)
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 
     func testHookEvaluationOrder() {
@@ -127,7 +127,7 @@ final class HookSpecTests: XCTestCase {
                 "client finallyAfter",
                 "api finallyAfter",
             ])
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 }
 

--- a/Tests/OpenFeatureTests/ProviderEventsTests.swift
+++ b/Tests/OpenFeatureTests/ProviderEventsTests.swift
@@ -17,6 +17,6 @@ final class ProviderEventsTests: XCTestCase {
             }
         OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
-        XCTAssertNotNil(eventState)
+        withExtendedLifetime(eventState) {}
     }
 }


### PR DESCRIPTION
`withExtendedLifetime` is more explicative about our intention, rather than using a non-nil assertion as workaround to keep the object allocated. @joelekstrom

