### PR TITLE
fix: setProviderAndWait does not hang on ProviderError

### DIFF
--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -96,7 +96,7 @@ extension OpenFeatureAPI {
             var holder: [AnyCancellable] = []
             await withCheckedContinuation { continuation in
                 let stateObserver = provider.observe().sink {
-                    if $0 == .ready {
+                    if $0 == .ready || $0 == .error {
                         continuation.resume()
                         holder.removeAll()
                     }

--- a/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
+++ b/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
@@ -73,12 +73,24 @@ final class DeveloperExperienceTests: XCTestCase {
             let provider = InjectableEventHandlerProvider(eventHandler: eventHandler)
             Task {
                 await OpenFeatureAPI.shared.setProviderAndWait(provider: provider)
-                wait(for: [readyExpectation], timeout: 0)
+                wait(for: [readyExpectation], timeout: 1)
                 initCompleteExpectation.fulfill()
             }
+
             wait(for: [staleExpectation], timeout: 1)
             eventHandler.send(.ready)
-            wait(for: [initCompleteExpectation], timeout: 2)
+            wait(for: [initCompleteExpectation], timeout: 1)
+
+            let errorProviderExpectation = XCTestExpectation()
+            let brokenProvider = AlwaysBrokenProvider()
+            Task {
+                await OpenFeatureAPI.shared.setProviderAndWait(provider: brokenProvider)
+                wait(for: [errorExpectation], timeout: 2)
+                errorProviderExpectation.fulfill()
+            }
+
+            eventHandler.send(.error)
+            wait(for: [errorProviderExpectation], timeout: 2)
         }
     }
 


### PR DESCRIPTION
## This PR
`setProviderAndWait` returns if `ProviderError` event has been emitted

### Related Issues
N/A

### How to test
Unit test added
