### PR TITLE
feat: Add ProviderNotReady event

### DIFF
--- a/Sources/OpenFeature/EventHandler.swift
+++ b/Sources/OpenFeature/EventHandler.swift
@@ -4,8 +4,12 @@ import Combine
 public class EventHandler: EventSender, EventPublisher {
     private let eventState: CurrentValueSubject<ProviderEvent, Never>
 
+    convenience init() {
+        self.init(.notReady)
+    }
+
     public init(_ state: ProviderEvent) {
-        eventState = CurrentValueSubject<ProviderEvent, Never>(ProviderEvent.stale)
+        eventState = CurrentValueSubject<ProviderEvent, Never>(state)
     }
 
     public func observe() -> AnyPublisher<ProviderEvent, Never> {

--- a/Sources/OpenFeature/Provider/NoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/NoOpProvider.swift
@@ -4,7 +4,7 @@ import Combine
 /// A ``FeatureProvider`` that simply returns the default values passed to it.
 class NoOpProvider: FeatureProvider {
     public static let passedInDefault = "Passed in default"
-    private let eventHandler = EventHandler(.ready)
+    private let eventHandler = EventHandler()
 
     public enum Mode {
         case normal

--- a/Sources/OpenFeature/Provider/ProviderEvents.swift
+++ b/Sources/OpenFeature/Provider/ProviderEvents.swift
@@ -9,4 +9,5 @@ public enum ProviderEvent: String, CaseIterable {
     case error = "PROVIDER_ERROR"
     case configurationChanged = "PROVIDER_CONFIGURATION_CHANGED"
     case stale = "PROVIDER_STALE"
+    case notReady = "PROVIDER_NOT_READY"
 }

--- a/Tests/OpenFeatureTests/FlagEvaluationTests.swift
+++ b/Tests/OpenFeatureTests/FlagEvaluationTests.swift
@@ -53,23 +53,26 @@ final class FlagEvaluationTests: XCTestCase {
 
     func testSimpleFlagEvaluation() {
         let provider = DoSomethingProvider()
+        let notReadyExpectation = XCTestExpectation(description: "NotReady")
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
         let eventState = provider.observe().sink { event in
             switch event {
-            case ProviderEvent.ready:
+            case .notReady:
+                notReadyExpectation.fulfill()
+            case .ready:
                 readyExpectation.fulfill()
-            case ProviderEvent.error:
+            case .error:
                 errorExpectation.fulfill()
-            case ProviderEvent.stale:
+            case .stale:
                 staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }
         }
 
-        wait(for: [staleExpectation], timeout: 5)
+        wait(for: [notReadyExpectation], timeout: 5)
         OpenFeatureAPI.shared.setProvider(provider: provider)
         wait(for: [readyExpectation], timeout: 5)
         let client = OpenFeatureAPI.shared.getClient()
@@ -109,17 +112,14 @@ final class FlagEvaluationTests: XCTestCase {
 
     func testDetailedFlagEvaluation() async {
         let provider = DoSomethingProvider()
+        let notReadyExpectation = XCTestExpectation(description: "NotReady")
         let readyExpectation = XCTestExpectation(description: "Ready")
-        let errorExpectation = XCTestExpectation(description: "Error")
-        let staleExpectation = XCTestExpectation(description: "Stale")
         let eventState = provider.observe().sink { event in
             switch event {
-            case ProviderEvent.ready:
+            case .notReady:
+                notReadyExpectation.fulfill()
+            case .ready:
                 readyExpectation.fulfill()
-            case ProviderEvent.error:
-                errorExpectation.fulfill()
-            case ProviderEvent.stale:
-                staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }
@@ -170,17 +170,14 @@ final class FlagEvaluationTests: XCTestCase {
 
     func testHooksAreFired() async {
         let provider = NoOpProvider()
+        let notReadyExpectation = XCTestExpectation(description: "NotReady")
         let readyExpectation = XCTestExpectation(description: "Ready")
-        let errorExpectation = XCTestExpectation(description: "Error")
-        let staleExpectation = XCTestExpectation(description: "Stale")
         let eventState = provider.observe().sink { event in
             switch event {
-            case ProviderEvent.ready:
+            case .notReady:
+                notReadyExpectation.fulfill()
+            case .ready:
                 readyExpectation.fulfill()
-            case ProviderEvent.error:
-                errorExpectation.fulfill()
-            case ProviderEvent.stale:
-                staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }
@@ -207,16 +204,19 @@ final class FlagEvaluationTests: XCTestCase {
 
     func testBrokenProvider() {
         let provider = AlwaysBrokenProvider()
+        let notReadyExpectation = XCTestExpectation(description: "NotReady")
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
         let staleExpectation = XCTestExpectation(description: "Stale")
         let eventState = provider.observe().sink { event in
             switch event {
-            case ProviderEvent.ready:
+            case .notReady:
+                notReadyExpectation.fulfill()
+            case .ready:
                 readyExpectation.fulfill()
-            case ProviderEvent.error:
+            case .error:
                 errorExpectation.fulfill()
-            case ProviderEvent.stale:
+            case .stale:
                 staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")

--- a/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
@@ -6,7 +6,7 @@ import Combine
 class AlwaysBrokenProvider: FeatureProvider {
     var metadata: ProviderMetadata = AlwaysBrokenMetadata()
     var hooks: [any Hook] = []
-    private let eventHandler = EventHandler(.stale)
+    private let eventHandler = EventHandler()
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
         eventHandler.send(.error)

--- a/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
@@ -4,7 +4,7 @@ import Combine
 
 class DoSomethingProvider: FeatureProvider {
     public static let name = "Something"
-    private let eventHandler = EventHandler(.ready)
+    private let eventHandler = EventHandler(.notReady)
     private var holdit: AnyCancellable?
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {

--- a/Tests/OpenFeatureTests/Helpers/InjectableEventHandlerProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/InjectableEventHandlerProvider.swift
@@ -11,13 +11,11 @@ class InjectableEventHandlerProvider: FeatureProvider {
     }
 
     func onContextSet(oldContext: OpenFeature.EvaluationContext?, newContext: OpenFeature.EvaluationContext) {
-        // Emit stale, then let the parent test control events via eventHandler
-        eventHandler.send(.stale)
+        // Let the parent test control events via eventHandler
     }
 
     func initialize(initialContext: OpenFeature.EvaluationContext?) {
-        // Emit stale, then let the parent test control events via eventHandler
-        eventHandler.send(.stale)
+        // Let the parent test control events via eventHandler
     }
 
     var hooks: [any OpenFeature.Hook] = []

--- a/Tests/OpenFeatureTests/HookSpecTests.swift
+++ b/Tests/OpenFeatureTests/HookSpecTests.swift
@@ -6,17 +6,14 @@ import XCTest
 final class HookSpecTests: XCTestCase {
     func testNoErrorHookCalled() {
         let provider = NoOpProvider()
+        let notReadyExpectation = XCTestExpectation(description: "NotReady")
         let readyExpectation = XCTestExpectation(description: "Ready")
-        let errorExpectation = XCTestExpectation(description: "Error")
-        let staleExpectation = XCTestExpectation(description: "Stale")
         let eventState = provider.observe().sink { event in
             switch event {
-            case ProviderEvent.ready:
+            case .notReady:
+                notReadyExpectation.fulfill()
+            case .ready:
                 readyExpectation.fulfill()
-            case ProviderEvent.error:
-                errorExpectation.fulfill()
-            case ProviderEvent.stale:
-                staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }
@@ -42,17 +39,17 @@ final class HookSpecTests: XCTestCase {
 
     func testErrorHookButNoAfterCalled() {
         let provider = AlwaysBrokenProvider()
+        let notReadyExpectation = XCTestExpectation(description: "NotReady")
         let readyExpectation = XCTestExpectation(description: "Ready")
         let errorExpectation = XCTestExpectation(description: "Error")
-        let staleExpectation = XCTestExpectation(description: "Stale")
         let eventState = provider.observe().sink { event in
             switch event {
-            case ProviderEvent.ready:
+            case .notReady:
+                notReadyExpectation.fulfill()
+            case .ready:
                 readyExpectation.fulfill()
-            case ProviderEvent.error:
+            case .error:
                 errorExpectation.fulfill()
-            case ProviderEvent.stale:
-                staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }
@@ -84,17 +81,14 @@ final class HookSpecTests: XCTestCase {
         let providerMock = NoOpProviderMock(hooks: [
             BooleanHookMock(prefix: "provider", addEval: addEval)
         ])
+        let notReadyExpectation = XCTestExpectation(description: "NotReady")
         let readyExpectation = XCTestExpectation(description: "Ready")
-        let errorExpectation = XCTestExpectation(description: "Error")
-        let staleExpectation = XCTestExpectation(description: "Stale")
         let eventState = providerMock.observe().sink { event in
             switch event {
-            case ProviderEvent.ready:
+            case .notReady:
+                notReadyExpectation.fulfill()
+            case .ready:
                 readyExpectation.fulfill()
-            case ProviderEvent.error:
-                errorExpectation.fulfill()
-            case ProviderEvent.stale:
-                staleExpectation.fulfill()
             default:
                 XCTFail("Unexpected event")
             }


### PR DESCRIPTION
The specs define **separately** provider [EVENTS](https://openfeature.dev/specification/types#provider-events) and provider [STATUS](https://openfeature.dev/specification/types#provider-status). This PR doesn't quite yet introduce `ProviderStatus`, but rather extends the Events to include all the possible statuses (namely adding `notReady`). I am not sure if this compromise can be acceptable in the long run, or if we'll need to eventually add the Statuses separately. Nevertheless adding `notReady` gives the Providers a proper case to use at initialization time.

### Related Issues
~Shall we add the lack of `ProviderStatus` as an Issue?~
(_There is a [proposal](https://github.com/open-feature/spec/issues/238) to remove ProviderStatus from Provider_)
