### PR TITLE
feat!: Add support for Flag Metadata

### DIFF
--- a/Sources/OpenFeature/EventHandler.swift
+++ b/Sources/OpenFeature/EventHandler.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Combine
+import Foundation
 
 public class EventHandler: EventSender, EventPublisher {
     private let eventState: CurrentValueSubject<ProviderEvent, Never>

--- a/Sources/OpenFeature/FlagEvaluationDetails.swift
+++ b/Sources/OpenFeature/FlagEvaluationDetails.swift
@@ -6,12 +6,14 @@ public struct FlagEvaluationDetails<T: Equatable>: BaseEvaluation, Equatable {
     public var value: T
     public var variant: String?
     public var reason: String?
+    public var flagMetadata: [String: FlagMetadataValue]
     public var errorCode: ErrorCode?
     public var errorMessage: String?
 
     public init(
         flagKey: String,
         value: T,
+        flagMetadata: [String: FlagMetadataValue] = [:],
         variant: String? = nil,
         reason: String? = nil,
         errorCode: ErrorCode? = nil,
@@ -21,6 +23,7 @@ public struct FlagEvaluationDetails<T: Equatable>: BaseEvaluation, Equatable {
         self.value = value
         self.variant = variant
         self.reason = reason
+        self.flagMetadata = flagMetadata
         self.errorCode = errorCode
         self.errorMessage = errorMessage
     }
@@ -29,6 +32,7 @@ public struct FlagEvaluationDetails<T: Equatable>: BaseEvaluation, Equatable {
         return FlagEvaluationDetails(
             flagKey: flagKey,
             value: providerEval.value,
+            flagMetadata: providerEval.flagMetadata,
             variant: providerEval.variant,
             reason: providerEval.reason,
             errorCode: providerEval.errorCode,

--- a/Sources/OpenFeature/FlagMetadataValue.swift
+++ b/Sources/OpenFeature/FlagMetadataValue.swift
@@ -1,0 +1,102 @@
+import Foundation
+
+public enum FlagMetadataValue: Equatable, Codable {
+    case boolean(Bool)
+    case string(String)
+    case integer(Int64)
+    case double(Double)
+
+    public static func of<T>(_ value: T) -> FlagMetadataValue? {
+        if let value = value as? Bool {
+            return .boolean(value)
+        } else if let value = value as? String {
+            return .string(value)
+        } else if let value = value as? Int64 {
+            return .integer(value)
+        } else if let value = value as? Double {
+            return .double(value)
+        } else {
+            return nil
+        }
+    }
+
+    public func getTyped<T>() -> T? {
+        if let value = self as? T {
+            return value
+        }
+
+        switch self {
+        case .boolean(let value): return value as? T
+        case .string(let value): return value as? T
+        case .integer(let value): return value as? T
+        case .double(let value): return value as? T
+        }
+    }
+
+    public func asBoolean() -> Bool? {
+        if case let .boolean(bool) = self {
+            return bool
+        }
+
+        return nil
+    }
+
+    public func asString() -> String? {
+        if case let .string(string) = self {
+            return string
+        }
+
+        return nil
+    }
+
+    public func asInteger() -> Int64? {
+        if case let .integer(int64) = self {
+            return int64
+        }
+
+        return nil
+    }
+
+    public func asDouble() -> Double? {
+        if case let .double(double) = self {
+            return double
+        }
+
+        return nil
+    }
+}
+
+extension FlagMetadataValue: CustomStringConvertible {
+    public var description: String {
+        switch self {
+        case .boolean(let value):
+            return "\(value)"
+        case .string(let value):
+            return value
+        case .integer(let value):
+            return "\(value)"
+        case .double(let value):
+            return "\(value)"
+        }
+    }
+}
+
+extension FlagMetadataValue {
+    public func decode<T: Decodable>() throws -> T {
+        let data = try JSONSerialization.data(withJSONObject: toJson(value: self))
+        return try JSONDecoder().decode(T.self, from: data)
+    }
+
+    func toJson(value: FlagMetadataValue) -> Any {
+        switch value {
+        case .boolean(let bool):
+            return bool
+        case .string(let string):
+            return string
+        case .integer(let int64):
+            return int64
+        case .double(let double):
+            return double
+        }
+    }
+}

--- a/Sources/OpenFeature/OpenFeatureAPI.swift
+++ b/Sources/OpenFeature/OpenFeatureAPI.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Combine
+import Foundation
 
 /// A global singleton which holds base configuration for the OpenFeature library.
 /// Configuration here will be shared across all ``Client``s.

--- a/Sources/OpenFeature/Provider/NoOpProvider.swift
+++ b/Sources/OpenFeature/Provider/NoOpProvider.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Combine
+import Foundation
 
 /// A ``FeatureProvider`` that simply returns the default values passed to it.
 class NoOpProvider: FeatureProvider {

--- a/Sources/OpenFeature/Provider/ProviderEvaluation.swift
+++ b/Sources/OpenFeature/Provider/ProviderEvaluation.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public struct ProviderEvaluation<T> {
     public var value: T
+    public var flagMetadata: [String: FlagMetadataValue]
     public var variant: String?
     public var reason: String?
     public var errorCode: ErrorCode?
@@ -9,6 +10,7 @@ public struct ProviderEvaluation<T> {
 
     public init(
         value: T,
+        flagMetadata: [String: FlagMetadataValue] = [:],
         variant: String? = nil,
         reason: String? = nil,
         errorCode: ErrorCode? = nil,
@@ -16,6 +18,7 @@ public struct ProviderEvaluation<T> {
     ) {
         self.value = value
         self.variant = variant
+        self.flagMetadata = flagMetadata
         self.reason = reason
         self.errorCode = errorCode
         self.errorMessage = errorMessage

--- a/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
+++ b/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
@@ -52,18 +52,18 @@ final class DeveloperExperienceTests: XCTestCase {
         let errorExpectation = XCTestExpectation(description: "Error")
         withExtendedLifetime(
             OpenFeatureAPI.shared.observe().sink { event in
-            switch event {
-            case .notReady:
-                notReadyExpectation.fulfill()
-            case .ready:
-                readyExpectation.fulfill()
-            case .error:
-                errorExpectation.fulfill()
-            default:
-                XCTFail("Unexpected event")
+                switch event {
+                case .notReady:
+                    notReadyExpectation.fulfill()
+                case .ready:
+                    readyExpectation.fulfill()
+                case .error:
+                    errorExpectation.fulfill()
+                default:
+                    XCTFail("Unexpected event")
+                }
             }
-            })
-        {
+        ) {
             let initCompleteExpectation = XCTestExpectation()
 
             let eventHandler = EventHandler()

--- a/Tests/OpenFeatureTests/FlagEvaluationTests.swift
+++ b/Tests/OpenFeatureTests/FlagEvaluationTests.swift
@@ -1,6 +1,6 @@
+import Combine
 import Foundation
 import XCTest
-import Combine
 
 @testable import OpenFeature
 
@@ -129,35 +129,40 @@ final class FlagEvaluationTests: XCTestCase {
         wait(for: [readyExpectation], timeout: 5)
         let client = OpenFeatureAPI.shared.getClient()
         let key = "key"
-        let booleanDetails = FlagEvaluationDetails(flagKey: key, value: true, variant: nil)
+        let booleanDetails = FlagEvaluationDetails(
+            flagKey: key, value: true, flagMetadata: DoSomethingProvider.flagMetadataMap, variant: nil)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: false), booleanDetails)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: false), booleanDetails)
         XCTAssertEqual(
             client.getDetails(
                 key: key, defaultValue: false, options: FlagEvaluationOptions()), booleanDetails)
 
-        let stringDetails = FlagEvaluationDetails(flagKey: key, value: "tset", variant: nil)
+        let stringDetails = FlagEvaluationDetails(
+            flagKey: key, value: "tset", flagMetadata: DoSomethingProvider.flagMetadataMap, variant: nil)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: "test"), stringDetails)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: "test"), stringDetails)
         XCTAssertEqual(
             client.getDetails(
                 key: key, defaultValue: "test", options: FlagEvaluationOptions()), stringDetails)
 
-        let integerDetails = FlagEvaluationDetails(flagKey: key, value: Int64(400), variant: nil)
+        let integerDetails = FlagEvaluationDetails(
+            flagKey: key, value: Int64(400), flagMetadata: DoSomethingProvider.flagMetadataMap, variant: nil)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: 4), integerDetails)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: 4), integerDetails)
         XCTAssertEqual(
             client.getDetails(
                 key: key, defaultValue: 4, options: FlagEvaluationOptions()), integerDetails)
 
-        let doubleDetails = FlagEvaluationDetails(flagKey: key, value: 40.0, variant: nil)
+        let doubleDetails = FlagEvaluationDetails(
+            flagKey: key, value: 40.0, flagMetadata: DoSomethingProvider.flagMetadataMap, variant: nil)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: 0.4), doubleDetails)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: 0.4), doubleDetails)
         XCTAssertEqual(
             client.getDetails(
                 key: key, defaultValue: 0.4, options: FlagEvaluationOptions()), doubleDetails)
 
-        let objectDetails = FlagEvaluationDetails(flagKey: key, value: Value.null, variant: nil)
+        let objectDetails = FlagEvaluationDetails(
+            flagKey: key, value: Value.null, flagMetadata: DoSomethingProvider.flagMetadataMap, variant: nil)
         XCTAssertEqual(client.getDetails(key: key, defaultValue: .structure([:])), objectDetails)
         XCTAssertEqual(
             client.getDetails(key: key, defaultValue: .structure([:])), objectDetails)
@@ -242,5 +247,23 @@ final class FlagEvaluationTests: XCTestCase {
 
         let client = OpenFeatureAPI.shared.getClient(name: "test", version: nil)
         XCTAssertEqual(client.metadata.name, "test")
+    }
+
+    func testFlagMetadata() {
+        OpenFeatureAPI.shared.setProvider(provider: DoSomethingProvider())
+        let client = OpenFeatureAPI.shared.getClient()
+        let details = client.getDetails(key: "testkey", defaultValue: false)
+
+        // These test values are hard coded for all evaluations from the DoSomethingProvider
+        XCTAssertEqual(details.flagMetadata["int-metadata"]?.asInteger(), 99)
+        XCTAssertEqual(details.flagMetadata["double-metadata"]?.asDouble(), 98.4)
+        XCTAssertEqual(details.flagMetadata["string-metadata"]?.asString(), "hello-world")
+        XCTAssertEqual(details.flagMetadata["boolean-metadata"]?.asBoolean(), true)
+
+        // Non existent key
+        XCTAssertNil(details.flagMetadata["non-existent-key"])
+
+        // Invalid mapping an int to string returns nil
+        XCTAssertNil(details.flagMetadata["int-metadata"]?.asString())
     }
 }

--- a/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/AlwaysBrokenProvider.swift
@@ -1,5 +1,5 @@
-import Foundation
 import Combine
+import Foundation
 
 @testable import OpenFeature
 

--- a/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/DoSomethingProvider.swift
@@ -1,6 +1,6 @@
+import Combine
 import Foundation
 import OpenFeature
-import Combine
 
 class DoSomethingProvider: FeatureProvider {
     public static let name = "Something"
@@ -23,7 +23,7 @@ class DoSomethingProvider: FeatureProvider {
             Bool
         >
     {
-        return ProviderEvaluation(value: !defaultValue)
+        return ProviderEvaluation(value: !defaultValue, flagMetadata: DoSomethingProvider.flagMetadataMap)
     }
 
     func getStringEvaluation(key: String, defaultValue: String, context: EvaluationContext?) throws
@@ -31,7 +31,8 @@ class DoSomethingProvider: FeatureProvider {
             String
         >
     {
-        return ProviderEvaluation(value: String(defaultValue.reversed()))
+        return ProviderEvaluation(
+            value: String(defaultValue.reversed()), flagMetadata: DoSomethingProvider.flagMetadataMap)
     }
 
     func getIntegerEvaluation(key: String, defaultValue: Int64, context: EvaluationContext?) throws
@@ -39,7 +40,7 @@ class DoSomethingProvider: FeatureProvider {
             Int64
         >
     {
-        return ProviderEvaluation(value: defaultValue * 100)
+        return ProviderEvaluation(value: defaultValue * 100, flagMetadata: DoSomethingProvider.flagMetadataMap)
     }
 
     func getDoubleEvaluation(key: String, defaultValue: Double, context: EvaluationContext?) throws
@@ -47,7 +48,7 @@ class DoSomethingProvider: FeatureProvider {
             Double
         >
     {
-        return ProviderEvaluation(value: defaultValue * 100)
+        return ProviderEvaluation(value: defaultValue * 100, flagMetadata: DoSomethingProvider.flagMetadataMap)
     }
 
     func getObjectEvaluation(key: String, defaultValue: Value, context: EvaluationContext?) throws
@@ -55,7 +56,7 @@ class DoSomethingProvider: FeatureProvider {
             Value
         >
     {
-        return ProviderEvaluation(value: .null)
+        return ProviderEvaluation(value: .null, flagMetadata: DoSomethingProvider.flagMetadataMap)
     }
 
     func observe() -> AnyPublisher<ProviderEvent, Never> {
@@ -65,4 +66,11 @@ class DoSomethingProvider: FeatureProvider {
     public struct DoMetadata: ProviderMetadata {
         public var name: String? = DoSomethingProvider.name
     }
+
+    public static let flagMetadataMap = [
+        "int-metadata": FlagMetadataValue.integer(99),
+        "double-metadata": FlagMetadataValue.double(98.4),
+        "string-metadata": FlagMetadataValue.string("hello-world"),
+        "boolean-metadata": FlagMetadataValue.boolean(true),
+    ]
 }

--- a/Tests/OpenFeatureTests/Helpers/InjectableEventHandlerProvider.swift
+++ b/Tests/OpenFeatureTests/Helpers/InjectableEventHandlerProvider.swift
@@ -1,6 +1,6 @@
+import Combine
 import Foundation
 import OpenFeature
-import Combine
 
 class InjectableEventHandlerProvider: FeatureProvider {
     public static let name = "InjectableEventHandler"

--- a/Tests/OpenFeatureTests/ProviderEventsTests.swift
+++ b/Tests/OpenFeatureTests/ProviderEventsTests.swift
@@ -7,7 +7,8 @@ final class ProviderEventsTests: XCTestCase {
 
     func testReadyEventSent() {
         let readyExpectation = XCTestExpectation(description: "Ready")
-        let eventState = provider
+        let eventState =
+            provider
             .observe()
             .filter { event in
                 event == ProviderEvent.ready


### PR DESCRIPTION
## This PR
Adds support for Flag metadata as part of the evaluation details (both from the API perspective but also from the `ProviderEvaluation`). Consider this a breaking change for Provider implementations.

### Related Issues
Fixes #39 

### Notes
Some formatting and import ordering slipped in as well.
