### PR TITLE
fix: Make HookContext properties public

### DIFF
--- a/Sources/OpenFeature/HookContext.swift
+++ b/Sources/OpenFeature/HookContext.swift
@@ -2,10 +2,10 @@ import Foundation
 
 /// A data struct to hold immutable context that ``Hook`` instances use.
 public struct HookContext<T> {
-    var flagKey: String
-    var type: FlagValueType
-    var defaultValue: T
-    var ctx: EvaluationContext?
-    var clientMetadata: ClientMetadata?
-    var providerMetadata: ProviderMetadata?
+    public var flagKey: String
+    public var type: FlagValueType
+    public var defaultValue: T
+    public var ctx: EvaluationContext?
+    public var clientMetadata: ClientMetadata?
+    public var providerMetadata: ProviderMetadata?
 }


### PR DESCRIPTION
## This PR
- When writing a custom hook I notice that we cannot read the `HookContext` properties.
- This PR is making all the `HookContext` properties public.