### PR TITLE
build: lower min required macOS version

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "OpenFeature",
     platforms: [
         .iOS(.v14),
-        .macOS(.v12),
+        .macOS(.v11),
     ],
     products: [
         .library(


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
- Lowers the required macOS version to 11.

### Related Issues
Nope.

### Notes
SDK doesn't use any API available only in macOS 12.
Also, the current min required version for iOS is 14, released in the same year as macOS 11 (2020).
And we are planning to use open-feature, but our app targets are too low 😅.
