### PR TITLE
docs: Fix spec version label in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
 <!-- TODO: update this with the version of the SDK your implementation supports -->
 
   <a href="https://github.com/open-feature/spec/releases/tag/v0.8.0">
-    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.7.0&color=yellow&style=for-the-badge" />
+    <img alt="Specification" src="https://img.shields.io/static/v1?label=specification&message=v0.8.0&color=yellow&style=for-the-badge" />
   </a>
   <!-- x-release-please-start-version -->
 


### PR DESCRIPTION
Just a minor README fix following up #46 