### PR TITLE
feat: Add ImmutableContext implementation

### DIFF
--- a/Sources/OpenFeature/EvaluationContext.swift
+++ b/Sources/OpenFeature/EvaluationContext.swift
@@ -4,5 +4,4 @@ import Foundation
 public protocol EvaluationContext: Structure {
     func getTargetingKey() -> String
     func deepCopy() -> EvaluationContext
-    func setTargetingKey(targetingKey: String)
 }

--- a/Sources/OpenFeature/ImmutableContext.swift
+++ b/Sources/OpenFeature/ImmutableContext.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// The ``ImmutableContext`` is an ``EvaluationContext`` implementation which is immutable and thread-safe.
+/// It provides read-only access to context data and cannot be modified after creation.
+public struct ImmutableContext: EvaluationContext {
+    private let targetingKey: String
+    private let structure: ImmutableStructure
+
+    public init(targetingKey: String = "", structure: ImmutableStructure = ImmutableStructure()) {
+        self.targetingKey = targetingKey
+        self.structure = structure
+    }
+
+    public init(attributes: [String: Value]) {
+        self.init(structure: ImmutableStructure(attributes: attributes))
+    }
+
+    public func deepCopy() -> EvaluationContext {
+        return ImmutableContext(targetingKey: targetingKey, structure: structure.deepCopy())
+    }
+
+    public func getTargetingKey() -> String {
+        return targetingKey
+    }
+
+    public func keySet() -> Set<String> {
+        return structure.keySet()
+    }
+
+    public func getValue(key: String) -> Value? {
+        return structure.getValue(key: key)
+    }
+
+    public func asMap() -> [String: Value] {
+        return structure.asMap()
+    }
+
+    public func asObjectMap() -> [String: AnyHashable?] {
+        return structure.asObjectMap()
+    }
+}
+
+extension ImmutableContext {
+    /// Creates an immutable context from a mutable context
+    public init(from mutableContext: MutableContext) {
+        self.init(
+            targetingKey: mutableContext.getTargetingKey(),
+            structure: ImmutableStructure(attributes: mutableContext.asMap())
+        )
+    }
+}

--- a/Sources/OpenFeature/ImmutableStructure.swift
+++ b/Sources/OpenFeature/ImmutableStructure.swift
@@ -1,0 +1,54 @@
+import Foundation
+
+/// The ``ImmutableStructure`` is a ``Structure`` implementation which is immutable and thread-safe.
+/// It provides read-only access to structured data and cannot be modified after creation.
+public class ImmutableStructure: Structure {
+    private let attributes: [String: Value]
+
+    public init(attributes: [String: Value] = [:]) {
+        self.attributes = attributes
+    }
+
+    public func keySet() -> Set<String> {
+        return Set(attributes.keys)
+    }
+
+    public func getValue(key: String) -> Value? {
+        return attributes[key]
+    }
+
+    public func asMap() -> [String: Value] {
+        return attributes
+    }
+
+    public func asObjectMap() -> [String: AnyHashable?] {
+        return attributes.mapValues(convertValue)
+    }
+
+    public func deepCopy() -> ImmutableStructure {
+        return ImmutableStructure(attributes: attributes)
+    }
+}
+
+extension ImmutableStructure {
+    private func convertValue(value: Value) -> AnyHashable? {
+        switch value {
+        case .boolean(let value):
+            return value
+        case .string(let value):
+            return value
+        case .integer(let value):
+            return value
+        case .double(let value):
+            return value
+        case .date(let value):
+            return value
+        case .list(let value):
+            return value.map(convertValue)
+        case .structure(let value):
+            return value.mapValues(convertValue)
+        case .null:
+            return nil
+        }
+    }
+}

--- a/Sources/OpenFeature/MutableContext.swift
+++ b/Sources/OpenFeature/MutableContext.swift
@@ -28,12 +28,6 @@ public class MutableContext: EvaluationContext {
         }
     }
 
-    public func setTargetingKey(targetingKey: String) {
-        queue.sync {
-            self.targetingKey = targetingKey
-        }
-    }
-
     public func keySet() -> Set<String> {
         return queue.sync {
             structure.keySet()
@@ -62,7 +56,7 @@ public class MutableContext: EvaluationContext {
 extension MutableContext {
     @discardableResult
     public func add(key: String, value: Value) -> MutableContext {
-        queue.sync {
+        _ = queue.sync {
             self.structure.add(key: key, value: value)
         }
         return self

--- a/Tests/OpenFeatureTests/EvalContextTests.swift
+++ b/Tests/OpenFeatureTests/EvalContextTests.swift
@@ -4,8 +4,7 @@ import XCTest
 
 final class EvalContextTests: XCTestCase {
     func testContextStoresTargetingKey() {
-        let ctx = MutableContext()
-        ctx.setTargetingKey(targetingKey: "test")
+        let ctx = MutableContext(targetingKey: "test")
         XCTAssertEqual(ctx.getTargetingKey(), "test")
     }
 
@@ -166,14 +165,12 @@ final class EvalContextTests: XCTestCase {
         )
         XCTAssertEqual(copiedContext.getValue(key: "structure")?.asStructure()?["nested-int"]?.asInteger(), 200)
 
-        originalContext.setTargetingKey(targetingKey: "modified-key")
         originalContext.add(key: "string", value: .string("modified-value"))
         originalContext.add(key: "new-key", value: .string("new-value"))
 
         XCTAssertEqual(copiedContext.getTargetingKey(), "original-key")
         XCTAssertEqual(copiedContext.getValue(key: "string")?.asString(), "original-value")
         XCTAssertNil(copiedContext.getValue(key: "new-key"))
-        XCTAssertEqual(originalContext.getTargetingKey(), "modified-key")
         XCTAssertEqual(originalContext.getValue(key: "string")?.asString(), "modified-value")
         XCTAssertEqual(originalContext.getValue(key: "new-key")?.asString(), "new-value")
     }
@@ -190,7 +187,6 @@ final class EvalContextTests: XCTestCase {
         XCTAssertTrue(emptyContext.keySet().isEmpty)
         XCTAssertTrue(copiedContext.keySet().isEmpty)
 
-        emptyContext.setTargetingKey(targetingKey: "test")
         emptyContext.add(key: "key", value: .string("value"))
 
         XCTAssertEqual(copiedContext.getTargetingKey(), "")
@@ -245,14 +241,12 @@ final class EvalContextTests: XCTestCase {
             group.enter()
             concurrentQueue.async {
                 // Modify the context
-                context.setTargetingKey(targetingKey: "modified-\(i)")
                 context.add(key: "key-\(i)", value: .integer(Int64(i)))
 
                 // Perform deep copy
                 let copiedContext = context.deepCopy()
 
                 // Verify the copy is independent
-                XCTAssertNotEqual(copiedContext.getTargetingKey(), "initial-key")
                 XCTAssertNotNil(copiedContext.getValue(key: "initial"))
 
                 group.leave()

--- a/Tests/OpenFeatureTests/ImmutableContextTests.swift
+++ b/Tests/OpenFeatureTests/ImmutableContextTests.swift
@@ -1,0 +1,102 @@
+import XCTest
+@testable import OpenFeature
+
+final class ImmutableContextTests: XCTestCase {
+    func testImmutableContextCreation() {
+        let context = ImmutableContext(targetingKey: "test-key")
+
+        XCTAssertEqual(context.getTargetingKey(), "test-key")
+        XCTAssertTrue(context.keySet().isEmpty)
+    }
+
+    func testImmutableContextWithAttributes() {
+        let attributes: [String: Value] = [
+            "string": .string("test-value"),
+            "integer": .integer(42),
+            "boolean": .boolean(true),
+        ]
+
+        let context = ImmutableContext(attributes: attributes)
+
+        XCTAssertEqual(context.getTargetingKey(), "")
+        XCTAssertEqual(context.keySet().count, 3)
+        XCTAssertEqual(context.getValue(key: "string")?.asString(), "test-value")
+        XCTAssertEqual(context.getValue(key: "integer")?.asInteger(), 42)
+        XCTAssertEqual(context.getValue(key: "boolean")?.asBoolean(), true)
+    }
+
+    func testImmutableContextDeepCopy() {
+        let original = ImmutableContext(
+            targetingKey: "original-key",
+            structure: ImmutableStructure(attributes: [
+                "key": .string("value")
+            ])
+        )
+
+        guard let copy = original.deepCopy() as? ImmutableContext else {
+            XCTFail("deepCopy() did not return an ImmutableContext")
+            return
+        }
+
+        XCTAssertEqual(copy.getTargetingKey(), "original-key")
+        XCTAssertEqual(copy.getValue(key: "key")?.asString(), "value")
+        XCTAssertEqual(original.getTargetingKey(), "original-key")
+        XCTAssertEqual(original.getValue(key: "key")?.asString(), "value")
+    }
+
+    func testImmutableContextFromMutableContext() {
+        let mutableContext = MutableContext(targetingKey: "mutable-key")
+        mutableContext.add(key: "string", value: .string("mutable-value"))
+        mutableContext.add(key: "number", value: .integer(123))
+
+        let immutableContext = ImmutableContext(from: mutableContext)
+
+        XCTAssertEqual(immutableContext.getTargetingKey(), "mutable-key")
+        XCTAssertEqual(immutableContext.keySet().count, 2)
+        XCTAssertEqual(immutableContext.getValue(key: "string")?.asString(), "mutable-value")
+        XCTAssertEqual(immutableContext.getValue(key: "number")?.asInteger(), 123)
+    }
+
+    func testImmutableContextAsMap() {
+        let attributes: [String: Value] = [
+            "string": .string("test"),
+            "integer": .integer(42),
+            "boolean": .boolean(true),
+            "list": .list([.string("item1"), .integer(100)]),
+            "structure": .structure([
+                "nested": .string("nested-value")
+            ]),
+        ]
+
+        let context = ImmutableContext(attributes: attributes)
+        let map = context.asMap()
+
+        XCTAssertEqual(map.count, 5)
+        XCTAssertEqual(map["string"]?.asString(), "test")
+        XCTAssertEqual(map["integer"]?.asInteger(), 42)
+        XCTAssertEqual(map["boolean"]?.asBoolean(), true)
+        XCTAssertEqual(map["list"]?.asList()?.count, 2)
+        XCTAssertEqual(map["structure"]?.asStructure()?["nested"]?.asString(), "nested-value")
+    }
+
+    func testImmutableContextAsObjectMap() {
+        let attributes: [String: Value] = [
+            "string": .string("test"),
+            "integer": .integer(42),
+            "boolean": .boolean(true),
+            "null": .null,
+        ]
+
+        let context = ImmutableContext(attributes: attributes)
+        let objectMap = context.asObjectMap()
+
+        XCTAssertEqual(objectMap.count, 4)
+        XCTAssertEqual(objectMap["string"] as? String, "test")
+        XCTAssertEqual(objectMap["integer"] as? Int64, 42)
+        XCTAssertEqual(objectMap["boolean"] as? Bool, true)
+
+        // For null values, we need to check the unwrapped value
+        let nullValue = objectMap["null"]
+        XCTAssertNil(nullValue as? AnyHashable) // But the unwrapped value is nil
+    }
+}


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
`ImmutableContext` is thread safe and our new suggested way to interact with the context APIs.
This PR also removes the setTargetingKey API from the EvaluationContext protocol, since it's not recommended to edit a context object anyway and would force our immutable implementation to expose a throwing/noop implementation for it.

### Related Issues
Reported crashes in the Confidence Provider likely caused by the passed context objected mutate at runtime
