### PR TITLE
fix: enable CocoaPods publishing by correcting release-please workflow outputs

### DIFF
--- a/.github/workflows/release-please.yaml
+++ b/.github/workflows/release-please.yaml
@@ -24,12 +24,12 @@ jobs:
         run: |
           echo "$RELEASE_PLEASE_OUTPUT"
 
-    # Outputs are namespaced by package when using a manifest in Release Please
+    # Outputs are not namespaced when using simple release type with root path
     outputs:
-      release_created: ${{ steps.release.outputs['OpenFeature--release_created'] }}
+      release_created: ${{ steps.release.outputs.release_created }}
       # Version doesn't include `v` as a prefix. This is undocumented
-      version: ${{ steps.release.outputs['OpenFeature--version'] }}
-      upload_url: ${{ steps.release.outputs['OpenFeature--upload_url'] }}
+      version: ${{ steps.release.outputs.version }}
+      upload_url: ${{ steps.release.outputs.upload_url }}
 
   # Trigger the CocoaPods workflow when a release is created
   cocoapods:


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

Latest GitHub Release/SPM Version: [0.5.0](https://github.com/open-feature/swift-sdk/releases/tag/0.5.0)
Latest Published CocoaPods Version: 0.3.0 (because [the workflow has been getting skipped during releases](https://github.com/open-feature/swift-sdk/actions/runs/19297891762))

<img width="1626" height="107" alt="image" src="https://github.com/user-attachments/assets/5678eec0-ba7f-49c2-b6ff-e6adf7e053a8" />

- fixes CocoaPods publishing by correcting release-please workflow outputs which were causing publication to be skipped
- removes incorrect namespace prefix from workflow outputs (`OpenFeature--release_created` → `release_created`)
- updates comment to align with behavior for simple release type with root path

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes https://github.com/open-feature/swift-sdk/issues/91

### Notes
<!-- any additional notes for this PR -->

The workflow was incorrectly using namespaced outputs like `steps.release.outputs['OpenFeature--release_created']`, but the simple release type with root path (`.`) doesn't actually namespace outputs. This caused the CocoaPods job condition to evaluate to false, skipping publication.

Verified by examining workflow logs from the 0.5.0 release which show actual outputs are `release_created`, `version`, etc. without namespace prefixes.

```
% gh run list --workflow release-please.yaml --limit 3
STATUS  TITLE                                                                   WORKFLOW            BRANCH  EVENT  ID           ELAPSED  AGE              
✓       chore(deps): update amannn/action-semantic-pull-request action to v6 …  Run Release Please  main    push   19442473525  16s      about 17 days ago
✓       chore: update copyright and gitignore (#88)                             Run Release Please  main    push   19442153404  23s      about 17 days ago
✓       chore(main): release 0.5.0 (#73)                                        Run Release Please  main    push   19297891762  17s      about 22 days ago
% gh run view 19297891762 --log | grep -A10 -B10 "release_created\|Dump Release Please Output"
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8719301Z ❯ targetBranch: main
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8721712Z ❯ commits: 0
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8725336Z ✔ Considering: 0 commits
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8726276Z ✔ No commits for path: ., skipping
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8955456Z ##[group]Run echo "$RELEASE_PLEASE_OUTPUT"
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8955895Z echo "$RELEASE_PLEASE_OUTPUT"
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8993497Z shell: /usr/bin/bash -e {0}
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8993806Z env:
release-please  UNKNOWN STEP    2025-11-12T12:45:25.8999929Z   RELEASE_PLEASE_OUTPUT: {
release-please  UNKNOWN STEP      "releases_created": "true",
release-please  UNKNOWN STEP      "release_created": "true",
release-please  UNKNOWN STEP      "id": "261739650",
release-please  UNKNOWN STEP      "name": "v0.5.0",
release-please  UNKNOWN STEP      "tag_name": "0.5.0",
release-please  UNKNOWN STEP      "sha": "d71686219a65ab78f77923ceb0e2ea549e1e50ef",
release-please  UNKNOWN STEP      "body": "## [0.5.0](https://github.com/open-feature/swift-sdk/compare/0.4.0...0.5.0) (2025-11-12)\n\n\n### ⚠ BREAKING CHANGES\n\n* add provider event details ([#77](https://github.com/open-feature/swift-sdk/issues/77))\n\n### 🐛 Bug Fixes\n\n* Prevent race condition on updateContext ([#84](https://github.com/open-feature/swift-sdk/issues/84)) ([dd23929](https://github.com/open-feature/swift-sdk/commit/dd239294e127ebf598f38227e4b9a85447576aff))\n\n\n### ✨ New Features\n\n* add multiprovider ([#78](https://github.com/open-feature/swift-sdk/issues/78)) ([869b90a](https://github.com/open-feature/swift-sdk/commit/869b90a7bf0c98368fe5b49f6c852178ba299ad7))\n* add provider event details ([#77](https://github.com/open-feature/swift-sdk/issues/77)) ([56b477e](https://github.com/open-feature/swift-sdk/commit/56b477e69250bc52feab0c9838234843d83b5732))\n* add Tracking API ([#81](https://github.com/open-feature/swift-sdk/issues/81)) ([c14b0cd](https://github.com/open-feature/swift-sdk/commit/c14b0cd6624c04801d16a801e4cf3412d522e4bd))\n* Allow FlagEvaluationDetails to be a public API ([#79](https://github.com/open-feature/swift-sdk/issues/79)) ([0b07a8f](https://github.com/open-feature/swift-sdk/commit/0b07a8ff1e790fe57de4608ff7ae2edaa8fdb48d))\n\n\n### 📚 Documentation\n\n* Update docs with ImmutableContext ([#72](https://github.com/open-feature/swift-sdk/issues/72)) ([28ccd3e](https://github.com/open-feature/swift-sdk/commit/28ccd3e0f71c2a015d507b8fba1fb294770ab74e))",
release-please  UNKNOWN STEP      "html_url": "https://github.com/open-feature/swift-sdk/releases/tag/0.5.0",
release-please  UNKNOWN STEP      "draft": "false",
release-please  UNKNOWN STEP      "upload_url": "https://uploads.github.com/repos/open-feature/swift-sdk/releases/261739650/assets{?name,label}",
release-please  UNKNOWN STEP      "path": ".",
release-please  UNKNOWN STEP      "version": "0.5.0",
release-please  UNKNOWN STEP      "major": "0",
release-please  UNKNOWN STEP      "minor": "5",
release-please  UNKNOWN STEP      "patch": "0",
release-please  UNKNOWN STEP      "paths_released": "[\".\"]"
release-please  UNKNOWN STEP    }
release-please  UNKNOWN STEP    2025-11-12T12:45:25.9006547Z ##[endgroup]
...
```

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

- Update the `COCOAPODS_TRUNK_TOKEN` repository secret with a fresh trunk token [as described in OWNERS.md](https://github.com/open-feature/swift-sdk/blob/main/OWNERS.md) if hasn't been kept up to date
  - The token expires every 128 days, and the `0.3.0` release was a while ago
```
% bundle exec pod trunk info OpenFeature
OpenFeature
    - Versions:
      - 0.3.0 (2024-05-23 16:00:30 UTC)
    - Owners:
      - OpenFeature <openfeature-core@groups.io>
```

### How to test
<!-- if applicable, add testing instructions under this section -->

- Monitor next release to confirm CocoaPods publishing works