### PR TITLE
fix: remove reference to deleted update_podspec.sh script

### DIFF
--- a/.github/workflows/cocoapods.yaml
+++ b/.github/workflows/cocoapods.yaml
@@ -20,7 +20,8 @@ jobs:
 
   pod-publish:
     needs: pod-lint
-    if: github.event_name == 'release'
+    # Run when triggered by a release event OR when called from release-please workflow
+    if: github.event_name == 'release' || github.event_name == 'workflow_call'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -32,7 +33,5 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          # Ensure the version in podspec matches the release
-          ./scripts/update_podspec.sh
           # Push the podspec to trunk
           pod trunk push OpenFeature.podspec --allow-warnings --verbose


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Removes reference to the deleted `update_podspec.sh` script from the CocoaPods workflow
  - The workflow will likely fail when run if it is referencing a missing script

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes https://github.com/open-feature/swift-sdk/issues/91

### Notes
<!-- any additional notes for this PR -->

The `update_podspec.sh` script was removed in https://github.com/open-feature/swift-sdk/commit/290300835dfe8d123651ea15ab27af6f6de30da4 when release-please was configured to automatically manage the podspec version. However, the CocoaPods workflow still referenced this missing script, causing the publishing step to fail.

This `# x-release-please-version` comment

https://github.com/open-feature/swift-sdk/blob/09ca50af82b51b433891fc4f25c8fee5fbf31336/OpenFeature.podspec#L3

is a [release-please marker](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files) that tells release-please to automatically update the version number during the release process. This generic updater works with any file type when configured in the `extra-files` option, eliminating the need for a separate script to update versions.

https://github.com/open-feature/swift-sdk/blob/09ca50af82b51b433891fc4f25c8fee5fbf31336/release-please-config.json#L10-L13

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

