### PR TITLE
fix: CocoaPods publishing workflow

### DIFF
--- a/.github/workflows/cocoapods.yaml
+++ b/.github/workflows/cocoapods.yaml
@@ -20,7 +20,6 @@ jobs:
 
   pod-publish:
     needs: pod-lint
-    if: github.event_name == 'release'
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
@@ -32,7 +31,5 @@ jobs:
         env:
           COCOAPODS_TRUNK_TOKEN: ${{ secrets.COCOAPODS_TRUNK_TOKEN }}
         run: |
-          # Ensure the version in podspec matches the release
-          ./scripts/update_podspec.sh
           # Push the podspec to trunk
           pod trunk push OpenFeature.podspec --allow-warnings --verbose


### PR DESCRIPTION
<!-- Please use this template for your pull request. -->
<!-- Please use the sections that you need and delete other sections -->

## This PR
<!-- add the description of the PR here -->

- Updates the workflow condition to trigger when called from release-please
- Removes reference to the deleted `update_podspec.sh` script from the CocoaPods workflow

### Related Issues
<!-- add here the GitHub issue that this PR resolves if applicable -->

Fixes #91 

### Notes
<!-- any additional notes for this PR -->

2 issues

1. **Overly restrictive publish condition**:
  - The recent fix to release-please outputs https://github.com/open-feature/swift-sdk/commit/09ca50af82b51b433891fc4f25c8fee5fbf31336 should trigger the CocoaPods workflow, but the `pod-publish` condition is
https://github.com/open-feature/swift-sdk/blob/09ca50af82b51b433891fc4f25c8fee5fbf31336/.github/workflows/cocoapods.yaml#L23
    - This would only allow publishing when triggered directly by GitHub release events, but that's not how release-please works. This repository's release-please workflow runs on `push` events 
https://github.com/open-feature/swift-sdk/blob/09ca50af82b51b433891fc4f25c8fee5fbf31336/.github/workflows/release-please.yaml#L1-L4
    - and calls CocoaPods via `workflow_call`
https://github.com/open-feature/swift-sdk/blob/09ca50af82b51b433891fc4f25c8fee5fbf31336/.github/workflows/release-please.yaml#L38
https://github.com/open-feature/swift-sdk/blob/09ca50af82b51b433891fc4f25c8fee5fbf31336/.github/workflows/cocoapods.yaml#L5
    - When called via `workflow_call` from a push-triggered workflow, the event context is inherited according to [GitHub documentation](https://docs.github.com/en/actions/reference/workflows-and-actions/events-that-trigger-workflows#workflow_call) and [GitHub issue #3146](https://github.com/actions/runner/issues/3146), **so `github.event_name` would be 'push', not 'release'**
  - **Proposed fix:** remove the condition entirely
    - Release-please already guards against accidental publishes with `release_created` check
    - Manual triggers via workflow_dispatch should allow publishing for recovery scenarios
    - GitHub release events should always trigger publishing
    - There aren't any `event_name` checks in the other OpenFeature SDKs using release-please
      - https://github.com/open-feature/go-sdk/blob/main/.github/workflows/release-please.yml
      - https://github.com/open-feature/js-sdk/blob/main/.github/workflows/release-please.yml

2. **Missing script**:
  - The `update_podspec.sh` script was removed in https://github.com/open-feature/swift-sdk/commit/290300835dfe8d123651ea15ab27af6f6de30da4 when release-please was configured to automatically manage the podspec version. However, the CocoaPods workflow still referenced this missing script, which would cause the publishing step to fail.
  - This `# x-release-please-version` comment
https://github.com/open-feature/swift-sdk/blob/09ca50af82b51b433891fc4f25c8fee5fbf31336/OpenFeature.podspec#L3
is a [release-please marker](https://github.com/googleapis/release-please/blob/main/docs/customizing.md#updating-arbitrary-files) that tells release-please to automatically update the version number on that line during the release process. This generic updater works with any file type when configured in the `extra-files` option, eliminating the need for a separate script to update versions.
https://github.com/open-feature/swift-sdk/blob/09ca50af82b51b433891fc4f25c8fee5fbf31336/release-please-config.json#L10-L13
  -  **Proposed fix:** remove reference to `./scripts/update_podspec.sh` in workflow

### Follow-up Tasks
<!-- anything that is related to this PR but not done here should be noted under this section -->
<!-- if there is a need for a new issue, please link it here -->

### How to test
<!-- if applicable, add testing instructions under this section -->

Will have to see if it works with the next release and check logs if it fails.