### PR TITLE
docs: fix inaccuracies in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This SDK supports the following Apple platforms:
 - **watchOS 8+**
 - **tvOS 15+**
 
-The SDK is built with Swift 5.5+ and uses only Foundation and Combine frameworks, making it suitable for all Apple platform contexts including mobile, desktop, wearable, and TV applications.
+The SDK is built with Swift 5.5+ and uses Foundation, Combine, and the [swift-log](https://github.com/apple/swift-log) Logging package, making it suitable for all Apple platform contexts including mobile, desktop, wearable, and TV applications.
 
 ### Install
 
@@ -80,7 +80,7 @@ and in the target dependencies section add:
 If you manage dependencies through CocoaPods, add the following to your Podfile:
 
 ```ruby
-pod 'OpenFeature', '~> 0.3.0'
+pod 'OpenFeature', '~> 0.5.0'
 ```
 
 Then, run:
@@ -425,7 +425,7 @@ class BooleanHook: Hook {
         // do something
     }
 
-    func finally<HookValue>(ctx: HookContext<HookValue>, hints: [String: Any]) {
+    func finally<HookValue>(ctx: HookContext<HookValue>, details: FlagEvaluationDetails<HookValue>, hints: [String: Any]) {
         // do something
     }
 }


### PR DESCRIPTION
## Summary

- Fix code example and version/dependency references in the README that would produce silent bugs or stale install commands

## Changes

1. **Requirements section**: Updated the dependency claim — the SDK depends on [swift-log](https://github.com/apple/swift-log) in addition to Foundation and Combine. `Package.swift` declares `swift-log` as a dependency and the `OpenFeature` target links `Logging`. The "only Foundation and Combine" claim predates the logging support
2. **CocoaPods instructions**: Updated `pod 'OpenFeature', '~> 0.3.0'` to `'~> 0.5.0'` to match the current podspec version (Swift Package Manager instructions in the same section already correctly reference `0.5.0`)
3. **Hook example — `finally` signature**: Added missing `details: FlagEvaluationDetails<HookValue>` parameter. Without it, the user's `finally` method has a different signature than the protocol method, so it doesn't override anything — the default no-op implementation runs instead and the user's code is silently skipped