### PR TITLE
fix!: restrict client tracking API to static-context signatures

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,12 +181,14 @@ For example, a flag enhancing the appearance of a UI component might drive user 
 ```swift
 let client = OpenFeatureAPI.shared.getClient()
 
-// Track an event
+// Track an event (uses the stored evaluation context on the client)
 client.track(key: "test")
 
 // Track an event with a numeric value
 client.track(key: "test-value", details: ImmutableTrackingEventDetails(value: 5))
 ```
+
+Set evaluation context via provider initialization or `OpenFeatureAPI.shared.setEvaluationContext(...)` before tracking. This client SDK follows the OpenFeature static-context tracking API and does not accept evaluation context at track invocation time.
 
 Note that some providers may not support tracking; check the documentation for your provider for more information.
 

--- a/Sources/OpenFeature/OpenFeatureClient.swift
+++ b/Sources/OpenFeature/OpenFeatureClient.swift
@@ -228,47 +228,24 @@ extension OpenFeatureClient {
 
 extension OpenFeatureClient {
     public func track(key: String) {
-        reportTrack(key: key, context: nil, details: nil)
-    }
-
-    public func track(key: String, context: any EvaluationContext) {
-        reportTrack(key: key, context: context, details: nil)
+        reportTrack(key: key, details: nil)
     }
 
     public func track(key: String, details: any TrackingEventDetails) {
-        reportTrack(key: key, context: nil, details: details)
+        reportTrack(key: key, details: details)
     }
 
-    public func track(key: String, context: any EvaluationContext, details: any TrackingEventDetails) {
-        reportTrack(key: key, context: context, details: details)
-    }
-
-    private func reportTrack(key: String, context: (any EvaluationContext)?, details: (any TrackingEventDetails)?) {
+    private func reportTrack(key: String, details: (any TrackingEventDetails)?) {
         let state = openFeatureApi.getState()
         do {
-            try state.provider?.track(key: key, context: mergeEvaluationContext(context), details: details)
+            try state.provider?.track(
+                key: key,
+                context: state.evaluationContext,
+                details: details
+            )
         } catch {
             let logger = lock.withLock { self.logger } ?? state.logger
             logger?.error("Unable to report track event with key \(key) due to exception \(error)")
-        }
-    }
-}
-
-extension OpenFeatureClient {
-    func mergeEvaluationContext(_ invocationContext: (any EvaluationContext)?) -> (any EvaluationContext)? {
-        let apiContext = OpenFeatureAPI.shared.getEvaluationContext()
-        return mergeContextMaps(apiContext, invocationContext)
-    }
-
-    private func mergeContextMaps(_ contexts: (any EvaluationContext)?...) -> (any EvaluationContext)? {
-        let validContexts = contexts.compactMap { $0 }
-        guard !validContexts.isEmpty else { return nil }
-
-        return validContexts.reduce(ImmutableContext()) { merged, next in
-            let newTargetingKey = next.getTargetingKey()
-            let targetingKey = newTargetingKey.isEmpty ? merged.getTargetingKey() : newTargetingKey
-            let attributes = merged.asMap().merging(next.asMap()) { _, newKey in newKey }
-            return ImmutableContext(targetingKey: targetingKey, structure: ImmutableStructure(attributes: attributes))
         }
     }
 }

--- a/Sources/OpenFeature/Tracking.swift
+++ b/Sources/OpenFeature/Tracking.swift
@@ -1,6 +1,9 @@
 import Foundation
 
-/// Interface for Tracking events.
+/// Interface for tracking events on static-context client SDKs.
+///
+/// Evaluation context is read from the stored client context (set via provider initialization or
+/// ``OpenFeatureAPI/setEvaluationContext(evaluationContext:)``), not passed at track invocation time.
 public protocol Tracking {
     /// Performs tracking of a particular action or application state.
     /// - Parameter key: Event name to track
@@ -8,17 +11,6 @@ public protocol Tracking {
     /// Performs tracking of a particular action or application state.
     /// - Parameters:
     ///   - key: Event name to track
-    ///   - context: Evaluation context used in flag evaluation
-    func track(key: String, context: any EvaluationContext)
-    /// Performs tracking of a particular action or application state.
-    /// - Parameters:
-    ///   - key: Event name to track
     ///   - details: Data pertinent to a particular tracking event
     func track(key: String, details: any TrackingEventDetails)
-    /// Performs tracking of a particular action or application state.
-    /// - Parameters:
-    ///   - key: Event name to track
-    ///   - context: Evaluation context used in flag evaluation
-    ///   - details: Data pertinent to a particular tracking event
-    func track(key: String, context: any EvaluationContext, details: any TrackingEventDetails)
 }

--- a/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
+++ b/Tests/OpenFeatureTests/DeveloperExperienceTests.swift
@@ -273,23 +273,4 @@ final class DeveloperExperienceTests: XCTestCase {
         XCTAssertTrue(trackCalled)
     }
 
-    func testTrackMergeContext() async {
-        var context: (any EvaluationContext)? = nil
-        let onTrack = { (_: String, evaluationContext: EvaluationContext?, _: TrackingEventDetails?) -> Void in
-            context = evaluationContext
-        }
-        await OpenFeatureAPI.shared.setProviderAndWait(provider: MockProvider(track: onTrack))
-        await OpenFeatureAPI.shared.setEvaluationContextAndWait(
-            evaluationContext: ImmutableContext(attributes: ["string": .string("user"), "num": .double(10)])
-        )
-        let client = OpenFeatureAPI.shared.getClient()
-        client.track(
-            key: "test", context: ImmutableContext(attributes: ["num": .double(20), "bool": .boolean(true)]),
-            details: ImmutableTrackingEventDetails(value: 5))
-
-        XCTAssertEqual(context?.keySet().count, 3)
-        XCTAssertEqual(context?.getValue(key: "string"), .string("user"))
-        XCTAssertEqual(context?.getValue(key: "num"), .double(20))
-        XCTAssertEqual(context?.getValue(key: "bool"), .boolean(true))
-    }
 }

--- a/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
+++ b/Tests/OpenFeatureTests/OpenFeatureClientTests.swift
@@ -33,58 +33,31 @@ final class OpenFeatureClientTests: XCTestCase {
         XCTAssertNotNil(eventState)
     }
 
-    func testMergeEvaluationContext_ApiEmptyAndInvocationNil_ThenEmpty() async {
-        let client = OpenFeatureClient(openFeatureApi: OpenFeatureAPI.shared, name: nil, version: nil)
-        await OpenFeatureAPI.shared.setEvaluationContextAndWait(evaluationContext: ImmutableContext())
-        let result = client.mergeEvaluationContext(nil)
-        XCTAssertTrue(result?.getTargetingKey().isEmpty == true)
-        XCTAssertTrue(result?.keySet().isEmpty == true)
-    }
-
-    func testMergeEvaluationContext_ApiContextAndInvocationNil_ThenApiContext() async {
-        let client = OpenFeatureClient(openFeatureApi: OpenFeatureAPI.shared, name: nil, version: nil)
-        let context = ImmutableContext(
-            targetingKey: "api", structure: ImmutableStructure(attributes: ["bool": .boolean(true)]))
-        await OpenFeatureAPI.shared.setEvaluationContextAndWait(evaluationContext: context)
-        let result = client.mergeEvaluationContext(nil)
-        XCTAssertEqual(result?.getTargetingKey(), context.getTargetingKey())
-        XCTAssertEqual(result?.asMap(), context.asMap())
-    }
-
-    func testMergeEvaluationContext_ApiNilAndInvocationContext_ThenInvocationContext() {
-        let client = OpenFeatureClient(openFeatureApi: OpenFeatureAPI.shared, name: nil, version: nil)
-        let context = ImmutableContext(
-            targetingKey: "invocation", structure: ImmutableStructure(attributes: ["bool": .boolean(true)]))
-        let result = client.mergeEvaluationContext(context)
-        XCTAssertEqual(result?.getTargetingKey(), context.getTargetingKey())
-        XCTAssertEqual(result?.asMap(), context.asMap())
-    }
-
-    func testMergeEvaluationContext_ApiContextAndInvocationContext_ThenMergedContext() async {
-        let client = OpenFeatureClient(openFeatureApi: OpenFeatureAPI.shared, name: nil, version: nil)
-        let apiContext = ImmutableContext(
-            targetingKey: "api",
-            structure: ImmutableStructure(attributes: ["bool": .boolean(true), "num": .integer(1)])
+    func testTrackPassesStoredEvaluationContextToProvider() async {
+        var receivedKey: String?
+        var receivedContext: (any EvaluationContext)?
+        var receivedDetails: (any TrackingEventDetails)?
+        let onTrack = { (key: String, evaluationContext: EvaluationContext?, details: TrackingEventDetails?) in
+            receivedKey = key
+            receivedContext = evaluationContext
+            receivedDetails = details
+        }
+        let storedContext = ImmutableContext(
+            targetingKey: "user-1",
+            structure: ImmutableStructure(attributes: ["plan": .string("premium"), "num": .double(10)])
         )
-        let invocationContext = ImmutableContext(
-            targetingKey: "invocation",
-            structure: ImmutableStructure(attributes: ["bool": .boolean(false), "string": .string("test")])
-        )
-        await OpenFeatureAPI.shared.setEvaluationContextAndWait(evaluationContext: apiContext)
-        let result = client.mergeEvaluationContext(invocationContext)
-        XCTAssertEqual(result?.getTargetingKey(), invocationContext.getTargetingKey())
-        XCTAssertEqual(result?.keySet().count, 3)
-        XCTAssertEqual(result?.getValue(key: "bool"), .boolean(false))
-        XCTAssertEqual(result?.getValue(key: "num"), .integer(1))
-        XCTAssertEqual(result?.getValue(key: "string"), .string("test"))
-    }
+        await OpenFeatureAPI.shared.setProviderAndWait(provider: MockProvider(track: onTrack))
+        await OpenFeatureAPI.shared.setEvaluationContextAndWait(evaluationContext: storedContext)
 
-    func testMergeEvaluationContext_ApiContextAndInvocationContextWithEmptyKey_ThenTargetingKeyNotOverriden() async {
-        let client = OpenFeatureClient(openFeatureApi: OpenFeatureAPI.shared, name: nil, version: nil)
-        let apiContext = ImmutableContext(targetingKey: "api")
-        let invocationContext = ImmutableContext(targetingKey: "")
-        await OpenFeatureAPI.shared.setEvaluationContextAndWait(evaluationContext: apiContext)
-        let result = client.mergeEvaluationContext(invocationContext)
-        XCTAssertEqual(result?.getTargetingKey(), "api")
+        OpenFeatureAPI.shared.getClient().track(
+            key: "test",
+            details: ImmutableTrackingEventDetails(value: 5)
+        )
+
+        XCTAssertEqual(receivedKey, "test")
+        XCTAssertEqual(receivedContext?.getTargetingKey(), storedContext.getTargetingKey())
+        XCTAssertEqual(receivedContext?.getValue(key: "plan"), .string("premium"))
+        XCTAssertEqual(receivedContext?.getValue(key: "num"), .double(10))
+        XCTAssertEqual(receivedDetails?.getValue(), 5)
     }
 }


### PR DESCRIPTION
## Summary

Fixes #123

Restricts the client `Tracking` API to static-context signatures only. Removes `track(key:context:)` overloads from `OpenFeatureClient` and passes the stored evaluation context to providers at track time instead of merging invocation context when `track` is called.

## Breaking change

Callers that used `track(key:context:)` (or other tracking overloads that accepted a per-invocation context) must migrate to setting evaluation context on the client (or using the static-context tracking methods) and calling `track` without a context parameter.

## Test plan

- [x] Run unit tests (`OpenFeatureClientTests`, `DeveloperExperienceTests`)
- [x] Verify README reflects the updated tracking API
- [ ] CI passes on this PR


Made with [Cursor](https://cursor.com)