### PR TITLE
fix!: use specification-compliant Reason raw values

### DIFF
--- a/Sources/OpenFeature/Reason.swift
+++ b/Sources/OpenFeature/Reason.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-/// Predefined resolution reasons.
-///
-/// Raw values are fixed by the OpenFeature specification and are compared as strings by
-/// consumers, so they cannot be changed without breaking them.
 public enum Reason: String {
     /// The resolved value is static (no dynamic evaluation).
     case staticReason = "STATIC"

--- a/Sources/OpenFeature/Reason.swift
+++ b/Sources/OpenFeature/Reason.swift
@@ -1,22 +1,26 @@
 import Foundation
 
+/// Predefined resolution reasons.
+///
+/// Raw values are fixed by the OpenFeature specification and are compared as strings by
+/// consumers, so they cannot be changed without breaking them.
 public enum Reason: String {
     /// The resolved value is static (no dynamic evaluation).
-    case staticReason
+    case staticReason = "STATIC"
     /// The resolved value was configured statically, or otherwise fell back to a pre-configured value.
-    case defaultReason
+    case defaultReason = "DEFAULT"
     /// The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting.
-    case targetingMatch
+    case targetingMatch = "TARGETING_MATCH"
     /// The resolved value was the result of pseudorandom assignment.
-    case split
+    case split = "SPLIT"
     /// The resolved value was retrieved from cache.
-    case cached
+    case cached = "CACHED"
     /// The resolved value was the result of the flag being disabled in the management system.
-    case disabled
+    case disabled = "DISABLED"
     /// The reason for the resolved value could not be determined.
-    case unknown
+    case unknown = "UNKNOWN"
     /// The resolved value is non-authoritative or possible out of date
-    case stale
+    case stale = "STALE"
     /// The resolved value was the result of an error.
-    case error
+    case error = "ERROR"
 }

--- a/Sources/OpenFeature/Reason.swift
+++ b/Sources/OpenFeature/Reason.swift
@@ -19,7 +19,7 @@ public enum Reason: String {
     case disabled = "DISABLED"
     /// The reason for the resolved value could not be determined.
     case unknown = "UNKNOWN"
-    /// The resolved value is non-authoritative or possible out of date
+    /// The resolved value is non-authoritative or possibly out of date.
     case stale = "STALE"
     /// The resolved value was the result of an error.
     case error = "ERROR"

--- a/Sources/OpenFeature/exceptions/ErrorCode.swift
+++ b/Sources/OpenFeature/exceptions/ErrorCode.swift
@@ -1,16 +1,12 @@
 import Foundation
 
-/// Predefined error codes.
-///
-/// Raw values are fixed by the OpenFeature specification and are compared as strings by
-/// consumers, so they cannot be changed without breaking them.
-public enum ErrorCode: String {
-    case providerNotReady = "PROVIDER_NOT_READY"
-    case flagNotFound = "FLAG_NOT_FOUND"
-    case parseError = "PARSE_ERROR"
-    case typeMismatch = "TYPE_MISMATCH"
-    case targetingKeyMissing = "TARGETING_KEY_MISSING"
-    case invalidContext = "INVALID_CONTEXT"
-    case general = "GENERAL"
-    case providerFatal = "PROVIDER_FATAL"
+public enum ErrorCode: Int {
+    case providerNotReady
+    case flagNotFound
+    case parseError
+    case typeMismatch
+    case targetingKeyMissing
+    case invalidContext
+    case general
+    case providerFatal
 }

--- a/Sources/OpenFeature/exceptions/ErrorCode.swift
+++ b/Sources/OpenFeature/exceptions/ErrorCode.swift
@@ -1,12 +1,16 @@
 import Foundation
 
-public enum ErrorCode: Int {
-    case providerNotReady
-    case flagNotFound
-    case parseError
-    case typeMismatch
-    case targetingKeyMissing
-    case invalidContext
-    case general
-    case providerFatal
+/// Predefined error codes.
+///
+/// Raw values are fixed by the OpenFeature specification and are compared as strings by
+/// consumers, so they cannot be changed without breaking them.
+public enum ErrorCode: String {
+    case providerNotReady = "PROVIDER_NOT_READY"
+    case flagNotFound = "FLAG_NOT_FOUND"
+    case parseError = "PARSE_ERROR"
+    case typeMismatch = "TYPE_MISMATCH"
+    case targetingKeyMissing = "TARGETING_KEY_MISSING"
+    case invalidContext = "INVALID_CONTEXT"
+    case general = "GENERAL"
+    case providerFatal = "PROVIDER_FATAL"
 }

--- a/Tests/OpenFeatureTests/ProviderSpecTests.swift
+++ b/Tests/OpenFeatureTests/ProviderSpecTests.swift
@@ -27,7 +27,7 @@ final class ProviderSpecTests: XCTestCase {
         let provider = NoOpProvider()
 
         let boolResult = try provider.getBooleanEvaluation(key: "key", defaultValue: false, context: MutableContext())
-        XCTAssertEqual(boolResult.reason, Reason.defaultReason.rawValue)
+        XCTAssertEqual(boolResult.reason, "DEFAULT")
     }
 
     func testNoErrorCodeByDefault() throws {

--- a/Tests/OpenFeatureTests/ReasonTests.swift
+++ b/Tests/OpenFeatureTests/ReasonTests.swift
@@ -2,8 +2,6 @@ import Foundation
 import OpenFeature
 import XCTest
 
-/// Asserts the literal strings, because assertions elsewhere compare `details.reason` against
-/// `Reason.x.rawValue` and so pass for any value.
 final class ReasonTests: XCTestCase {
     func testReasonRawValuesMatchSpecification() {
         XCTAssertEqual(Reason.staticReason.rawValue, "STATIC")

--- a/Tests/OpenFeatureTests/ReasonTests.swift
+++ b/Tests/OpenFeatureTests/ReasonTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import OpenFeature
+import XCTest
+
+/// Asserts the literal raw values, because assertions elsewhere compare `details.reason` against
+/// `Reason.x.rawValue` and so pass for any value.
+final class ReasonTests: XCTestCase {
+    func testReasonRawValuesMatchSpecification() {
+        XCTAssertEqual(Reason.staticReason.rawValue, "STATIC")
+        XCTAssertEqual(Reason.defaultReason.rawValue, "DEFAULT")
+        XCTAssertEqual(Reason.targetingMatch.rawValue, "TARGETING_MATCH")
+        XCTAssertEqual(Reason.split.rawValue, "SPLIT")
+        XCTAssertEqual(Reason.cached.rawValue, "CACHED")
+        XCTAssertEqual(Reason.disabled.rawValue, "DISABLED")
+        XCTAssertEqual(Reason.unknown.rawValue, "UNKNOWN")
+        XCTAssertEqual(Reason.stale.rawValue, "STALE")
+        XCTAssertEqual(Reason.error.rawValue, "ERROR")
+    }
+
+    func testErrorCodeRawValuesMatchSpecification() {
+        XCTAssertEqual(ErrorCode.providerNotReady.rawValue, "PROVIDER_NOT_READY")
+        XCTAssertEqual(ErrorCode.flagNotFound.rawValue, "FLAG_NOT_FOUND")
+        XCTAssertEqual(ErrorCode.parseError.rawValue, "PARSE_ERROR")
+        XCTAssertEqual(ErrorCode.typeMismatch.rawValue, "TYPE_MISMATCH")
+        XCTAssertEqual(ErrorCode.targetingKeyMissing.rawValue, "TARGETING_KEY_MISSING")
+        XCTAssertEqual(ErrorCode.invalidContext.rawValue, "INVALID_CONTEXT")
+        XCTAssertEqual(ErrorCode.general.rawValue, "GENERAL")
+        XCTAssertEqual(ErrorCode.providerFatal.rawValue, "PROVIDER_FATAL")
+    }
+}

--- a/Tests/OpenFeatureTests/ReasonTests.swift
+++ b/Tests/OpenFeatureTests/ReasonTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import OpenFeature
 import XCTest
 
-/// Asserts the literal raw values, because assertions elsewhere compare `details.reason` against
+/// Asserts the literal strings, because assertions elsewhere compare `details.reason` against
 /// `Reason.x.rawValue` and so pass for any value.
 final class ReasonTests: XCTestCase {
     func testReasonRawValuesMatchSpecification() {
@@ -15,16 +15,5 @@ final class ReasonTests: XCTestCase {
         XCTAssertEqual(Reason.unknown.rawValue, "UNKNOWN")
         XCTAssertEqual(Reason.stale.rawValue, "STALE")
         XCTAssertEqual(Reason.error.rawValue, "ERROR")
-    }
-
-    func testErrorCodeRawValuesMatchSpecification() {
-        XCTAssertEqual(ErrorCode.providerNotReady.rawValue, "PROVIDER_NOT_READY")
-        XCTAssertEqual(ErrorCode.flagNotFound.rawValue, "FLAG_NOT_FOUND")
-        XCTAssertEqual(ErrorCode.parseError.rawValue, "PARSE_ERROR")
-        XCTAssertEqual(ErrorCode.typeMismatch.rawValue, "TYPE_MISMATCH")
-        XCTAssertEqual(ErrorCode.targetingKeyMissing.rawValue, "TARGETING_KEY_MISSING")
-        XCTAssertEqual(ErrorCode.invalidContext.rawValue, "INVALID_CONTEXT")
-        XCTAssertEqual(ErrorCode.general.rawValue, "GENERAL")
-        XCTAssertEqual(ErrorCode.providerFatal.rawValue, "PROVIDER_FATAL")
     }
 }


### PR DESCRIPTION
## Intent

The specification types `reason` as a string field holding "any of the [pre-defined reasons](https://openfeature.dev/specification/types/#resolution-details), or any string value", and this SDK exposes it as `ProviderEvaluation.reason: String?` — so the emitted string is the public contract. It was emitting Swift-flavoured camelCase: `Reason.staticReason.rawValue` was `"staticReason"`, not `"STATIC"`. After this change the raw values are the pre-defined reasons. Enum case names are unchanged, so no Swift call site is affected.

`ErrorCode` is deliberately left as enum representation.

## Motivation

Evaluation reasons were not portable across SDKs, and the shared Gherkin suite (#105) asserts on them directly (`the reason should be "STATIC"`):

| SDK | `reason` field type | emitted value |
| --- | --- | --- |
| Java | `private String reason` | `"STATIC"` |
| Go | `Reason string` | `"STATIC"` |
| JS | `string` | `'STATIC'` |
| Swift (before) | `String?` | `"staticReason"` |
| Swift (after) | `String?` | `"STATIC"` |

The existing test suite could not detect this: every assertion compared `details.reason` against `Reason.x.rawValue`, so both sides moved together and any raw value would have passed.

## Changes

### Implementation

- `Reason` gains explicit raw values: `STATIC`, `DEFAULT`, `TARGETING_MATCH`, `SPLIT`, `CACHED`, `DISABLED`, `UNKNOWN`, `STALE`, `ERROR`.

### `ErrorCode` is intentionally unchanged to keep backward compatibility

## Testing

- New `ReasonTests` pins every `Reason` raw value to its specification literal, so a future edit cannot silently change the wire format.
- `ProviderSpecTests.testHasReason` now asserts the literal `"DEFAULT"` rather than `Reason.defaultReason.rawValue`, making the spec-conformance test actually spec-facing.

## Breaking Changes

Yes — the emitted reason strings change. Swift call sites using the enum cases are unaffected; code comparing `reason` to a string literal must be updated. Flagged with `fix!` and a `BREAKING CHANGE` footer so release-please surfaces the mapping in the changelog.
