### PR TITLE
test: add gherkin e2e suite for evaluation.feature

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -32,6 +32,16 @@ jobs:
               -destination "id=$SIMULATOR"
           fi
 
+  E2E:
+    runs-on: macOS-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # The Gherkin suite lives in the open-feature/spec submodule at spec/.
+          submodules: recursive
+      - name: Run the shared Gherkin suite
+        run: ./scripts/e2e
+
   SwiftLint:
     runs-on: ubuntu-latest
     steps:

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "spec"]
+	path = spec
+	url = https://github.com/open-feature/spec.git

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -4,6 +4,8 @@ excluded:
   - ${PWD}/DerivedData
   - ${PWD}/.build
   - ${PWD}/Tools/*/.build
+  - ${PWD}/e2e/.build
+  - ${PWD}/spec
   - ${PWD}/Tests/OpenFeatureTests/MockingbirdMocks/
   - ${PWD}/Sources/OpenFeature/FlagResolver
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,6 +2,10 @@
 
 To get started, open the project in Xcode and build by Product -> Build.
 
+This repository has a submodule holding the OpenFeature specification's shared test suite, so
+clone with `git clone --recurse-submodules`, or run `git submodule update --init` in an existing
+clone. Only the end-to-end tests need it.
+
 OpenFeature is not keen on vendor-specific stuff in this library, but if there are changes that need to happen in the spec to enable vendor-specific stuff in user code or other extension points, check out [the spec](https://github.com/open-feature/spec).
 
 ### Linting code
@@ -23,6 +27,35 @@ You can automatically format your code using:
 
 ```shell
 swift test
+```
+
+### Running the shared Gherkin e2e suite
+
+`e2e/` is a separate Swift package that runs the OpenFeature specification's shared
+`evaluation.feature` against `InMemoryProvider` using
+[CucumberSwift](https://github.com/cucumberswift/CucumberSwift). It is separate from the root
+package because CucumberSwift does not support watchOS and should not reach consumers of the SDK.
+
+```shell
+./scripts/e2e
+```
+
+That script initialises the [`open-feature/spec`](https://github.com/open-feature/spec) submodule,
+copies `spec/specification/assets/gherkin/evaluation.feature` into the test target's gitignored
+`Features/` directory, then runs `swift test` in `e2e/`. Only `evaluation.feature` is implemented;
+the other feature files are deliberately not copied, because CucumberSwift fails every step it has
+no expression for.
+
+Do **not** run `swift test` inside `e2e/` directly on a fresh clone: CucumberSwift asserts that it
+found at least one `.feature` file, so a missing one traps the test process. `--filter` is no use
+either, because CucumberSwift builds its test cases at runtime and SwiftPM finds none to match;
+filter by tag with `CUCUMBER_TAGS=deprecated ./scripts/e2e` instead.
+
+To bump the spec pin:
+
+```shell
+git -C spec fetch origin && git -C spec checkout <sha>
+git add spec && git commit -m "chore: bump spec submodule"
 ```
 
 ### Maintaining CocoaPods Integration

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ Task {
 | ✅     | [Logging](#logging)             | Integrate with popular logging packages.                                                                                            |
 | ❌     | [Domains](#domains)             | Logically bind clients with providers.                                                                                              |
 | ✅     | [MultiProvider](#multiprovider) | Combine multiple providers with configurable evaluation strategies.                                                                 |
+| ✅     | [InMemoryProvider](#inmemoryprovider) | Resolve flags from an in-memory configuration, for demos and testing.                                                         |
 | ✅     | [Eventing](#eventing)           | React to state changes in the provider or flag management system.                                                                   |
 | ❌     | [Shutdown](#shutdown)           | Gracefully clean up a provider during application shutdown.                                                                         |
 | ✅     | [Extending](#extending)         | Extend OpenFeature with custom providers and hooks.                                                                                 |
@@ -315,6 +316,51 @@ let providers = [
     DefaultProvider()
 ]
 let multiProvider = MultiProvider(providers: providers)
+```
+
+### InMemoryProvider
+
+`InMemoryProvider` resolves flags from a configuration you supply, with no network calls and no mocking. It is useful for demos, local development, and for testing hooks, providers, or application code that consumes flags.
+
+```swift
+let provider = InMemoryProvider(flags: [
+    "boolean-flag": InMemoryFlag(
+        variants: ["on": .boolean(true), "off": .boolean(false)],
+        defaultVariant: "on"),
+    "greeting": InMemoryFlag(
+        variants: ["formal": .string("Good evening"), "casual": .string("hi")],
+        defaultVariant: "formal",
+        flagMetadata: ["version": .string("1.0.2")]),
+])
+
+await OpenFeatureAPI.shared.setProviderAndWait(provider: provider)
+OpenFeatureAPI.shared.getClient().getBooleanValue(key: "boolean-flag", defaultValue: false)  // true
+```
+
+Targeting is expressed as a callback returning the key of the variant to resolve, or `nil` to fall back to the flag's `defaultVariant`:
+
+```swift
+InMemoryFlag(
+    variants: ["internal": .string("INTERNAL"), "external": .string("EXTERNAL")],
+    defaultVariant: "external",
+    contextEvaluator: { _, context in
+        context?.getValue(key: "customer") == .boolean(false) ? "internal" : nil
+    })
+```
+
+A resolution reports `TARGETING_MATCH` when the callback selects a variant, `DEFAULT` when it returns `nil`, `STATIC` when the flag has no callback, and `DISABLED` for a flag constructed with `disabled: true`. An unknown flag key resolves as `FLAG_NOT_FOUND`, and a variant whose value is not of the requested type as `TYPE_MISMATCH`.
+
+The configuration can be changed after the provider is registered, which emits `PROVIDER_CONFIGURATION_CHANGED`:
+
+```swift
+provider.updateFlag(key: "boolean-flag", flag: InMemoryFlag(
+    variants: ["on": .boolean(true), "off": .boolean(false)],
+    defaultVariant: "off"))
+
+provider.removeFlag(key: "greeting")
+
+// Replaces the whole configuration; the event reports the union of the old and new flag keys.
+provider.putConfiguration(["only-flag": InMemoryFlag(variants: ["on": .boolean(true)], defaultVariant: "on")])
 ```
 
 ### Eventing

--- a/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryFlag.swift
+++ b/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryFlag.swift
@@ -2,24 +2,12 @@ import Foundation
 
 /// A single flag definition used by ``InMemoryProvider``.
 public struct InMemoryFlag {
-    /// Resolves a flag against the evaluation context, for targeting.
-    ///
     /// Returns the key of the variant to resolve, or `nil` to fall back to ``defaultVariant``.
-    /// A key that is not present in ``variants`` fails evaluation with
-    /// ``OpenFeatureError/generalError(message:)``.
-    ///
-    /// The context is optional because no evaluation context exists until the application sets
-    /// one.
     public typealias ContextEvaluator = (InMemoryFlag, EvaluationContext?) -> String?
 
     public let variants: [String: Value]
-
-    /// Resolved when there is no ``contextEvaluator``, or when it returns `nil`.
     public let defaultVariant: String
-
     public let contextEvaluator: ContextEvaluator?
-
-    /// Attached to every evaluation of this flag, including disabled ones.
     public let flagMetadata: FlagMetadata
 
     /// When `true`, evaluations return the caller's default value with reason `DISABLED`.

--- a/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryFlag.swift
+++ b/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryFlag.swift
@@ -1,0 +1,41 @@
+import Foundation
+
+/// A single flag definition used by ``InMemoryProvider``.
+public struct InMemoryFlag {
+    /// Resolves a flag against the evaluation context, for targeting.
+    ///
+    /// Returns the key of the variant to resolve, or `nil` to fall back to ``defaultVariant``.
+    /// A key that is not present in ``variants`` fails evaluation with
+    /// ``OpenFeatureError/generalError(message:)``.
+    ///
+    /// The context is optional because no evaluation context exists until the application sets
+    /// one.
+    public typealias ContextEvaluator = (InMemoryFlag, EvaluationContext?) -> String?
+
+    public let variants: [String: Value]
+
+    /// Resolved when there is no ``contextEvaluator``, or when it returns `nil`.
+    public let defaultVariant: String
+
+    public let contextEvaluator: ContextEvaluator?
+
+    /// Attached to every evaluation of this flag, including disabled ones.
+    public let flagMetadata: FlagMetadata
+
+    /// When `true`, evaluations return the caller's default value with reason `DISABLED`.
+    public let disabled: Bool
+
+    public init(
+        variants: [String: Value],
+        defaultVariant: String,
+        contextEvaluator: ContextEvaluator? = nil,
+        flagMetadata: FlagMetadata = [:],
+        disabled: Bool = false
+    ) {
+        self.variants = variants
+        self.defaultVariant = defaultVariant
+        self.contextEvaluator = contextEvaluator
+        self.flagMetadata = flagMetadata
+        self.disabled = disabled
+    }
+}

--- a/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryProvider.swift
+++ b/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryProvider.swift
@@ -115,8 +115,10 @@ public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
     public func getObjectEvaluation(key: String, defaultValue: Value, context: EvaluationContext?) throws
         -> ProviderEvaluation<Value>
     {
-        // Every variant is already a `Value`, so this never reports a type mismatch.
-        return try resolve(key: key, defaultValue: defaultValue, context: context) { $0 }
+        return try resolve(key: key, defaultValue: defaultValue, context: context) { value in
+            guard case .structure = value else { return nil }
+            return value
+        }
     }
 
     private func resolve<T>(

--- a/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryProvider.swift
+++ b/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryProvider.swift
@@ -2,8 +2,6 @@ import Combine
 import Foundation
 
 /// A ``FeatureProvider`` that resolves flags from an in-memory configuration.
-///
-/// See the InMemoryProvider section of the README for usage.
 public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
     public static let name = "InMemoryProvider"
 
@@ -12,8 +10,8 @@ public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
 
     private let statusTracker = ProviderStatusTracker()
 
-    /// Never held while emitting an event: `ProviderStatusTracker.send` takes its own lock and
-    /// delivers to subscribers, so a subscriber touching the configuration would deadlock.
+    /// Never held while calling `statusTracker.send`, which delivers to subscribers and could
+    /// deadlock if one of them touches the configuration back.
     private let flagsLock = NSLock()
     private var _flags: [String: InMemoryFlag]
 
@@ -21,9 +19,12 @@ public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
         self._flags = flags
     }
 
-    /// A snapshot of the current flag configuration.
     public var flags: [String: InMemoryFlag] {
         return flagsLock.withLock { _flags }
+    }
+
+    private func flag(forKey key: String) -> InMemoryFlag? {
+        return flagsLock.withLock { _flags[key] }
     }
 
     public var status: ProviderStatus {
@@ -47,8 +48,7 @@ public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
     ) -> Future<Void, Never> {
-        // No `.reconciling`: nothing is cached per context, so there is no asynchronous work for
-        // it to describe.
+        // No async work happens per context, so there's nothing for `.reconciling` to describe.
         statusTracker.send(.contextChanged(nil))
         return Future { promise in
             promise(.success(()))
@@ -57,26 +57,23 @@ public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
 
     // MARK: - Configuration
 
-    /// Replaces the entire flag configuration, emitting `.configurationChanged` whose
-    /// `flagsChanged` is the union of all previous and all new flag keys, per the specification.
+    /// Replaces the entire flag configuration. `flagsChanged` is the union of the previous and
+    /// new flag keys, per the specification.
     public func putConfiguration(_ flags: [String: InMemoryFlag]) {
-        let flagsChanged: [String] = flagsLock.withLock {
+        let union: Set<String> = flagsLock.withLock {
             let union = Set(_flags.keys).union(flags.keys)
             _flags = flags
-            return union.sorted()
+            return union
         }
-        send(flagsChanged: flagsChanged, message: "flags changed")
+        send(flagsChanged: union.sorted(), message: "flags changed")
     }
 
-    /// Adds or replaces a single flag, emitting `.configurationChanged` for that key.
     public func updateFlag(key: String, flag: InMemoryFlag) {
         flagsLock.withLock { _flags[key] = flag }
         send(flagsChanged: [key], message: "flag added/updated")
     }
 
-    /// Removes a single flag, emitting `.configurationChanged` for that key.
-    ///
-    /// Nothing is emitted when the flag was not present.
+    /// No event is emitted when the flag was not present.
     public func removeFlag(key: String) {
         let existed = flagsLock.withLock { _flags.removeValue(forKey: key) != nil }
         guard existed else { return }
@@ -118,11 +115,10 @@ public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
     public func getObjectEvaluation(key: String, defaultValue: Value, context: EvaluationContext?) throws
         -> ProviderEvaluation<Value>
     {
-        // Every variant already is a `Value`, so this never reports a type mismatch.
+        // Every variant is already a `Value`, so this never reports a type mismatch.
         return try resolve(key: key, defaultValue: defaultValue, context: context) { $0 }
     }
 
-    /// - Parameter coerce: returns `nil` when the stored variant holds a different type.
     private func resolve<T>(
         key: String,
         defaultValue: T,
@@ -135,7 +131,7 @@ public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
             throw OpenFeatureError.providerNotReadyError
         }
 
-        guard let flag = flags[key] else {
+        guard let flag = flag(forKey: key) else {
             throw OpenFeatureError.flagNotFoundError(key: key)
         }
 

--- a/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryProvider.swift
+++ b/Sources/OpenFeature/Provider/InMemoryProvider/InMemoryProvider.swift
@@ -1,0 +1,185 @@
+import Combine
+import Foundation
+
+/// A ``FeatureProvider`` that resolves flags from an in-memory configuration.
+///
+/// See the InMemoryProvider section of the README for usage.
+public final class InMemoryProvider: FeatureProvider, @unchecked Sendable {
+    public static let name = "InMemoryProvider"
+
+    public var hooks: [any Hook] { [] }
+    public let metadata: ProviderMetadata = InMemoryProviderMetadata()
+
+    private let statusTracker = ProviderStatusTracker()
+
+    /// Never held while emitting an event: `ProviderStatusTracker.send` takes its own lock and
+    /// delivers to subscribers, so a subscriber touching the configuration would deadlock.
+    private let flagsLock = NSLock()
+    private var _flags: [String: InMemoryFlag]
+
+    public init(flags: [String: InMemoryFlag] = [:]) {
+        self._flags = flags
+    }
+
+    /// A snapshot of the current flag configuration.
+    public var flags: [String: InMemoryFlag] {
+        return flagsLock.withLock { _flags }
+    }
+
+    public var status: ProviderStatus {
+        return statusTracker.status
+    }
+
+    public func observe() -> AnyPublisher<ProviderEvent, Never> {
+        return statusTracker.observe()
+    }
+
+    // MARK: - Lifecycle
+
+    public func initialize(initialContext: EvaluationContext?) -> Future<Void, Never> {
+        statusTracker.send(.ready(nil))
+        return Future { promise in
+            promise(.success(()))
+        }
+    }
+
+    public func onContextSet(
+        oldContext: EvaluationContext?,
+        newContext: EvaluationContext
+    ) -> Future<Void, Never> {
+        // No `.reconciling`: nothing is cached per context, so there is no asynchronous work for
+        // it to describe.
+        statusTracker.send(.contextChanged(nil))
+        return Future { promise in
+            promise(.success(()))
+        }
+    }
+
+    // MARK: - Configuration
+
+    /// Replaces the entire flag configuration, emitting `.configurationChanged` whose
+    /// `flagsChanged` is the union of all previous and all new flag keys, per the specification.
+    public func putConfiguration(_ flags: [String: InMemoryFlag]) {
+        let flagsChanged: [String] = flagsLock.withLock {
+            let union = Set(_flags.keys).union(flags.keys)
+            _flags = flags
+            return union.sorted()
+        }
+        send(flagsChanged: flagsChanged, message: "flags changed")
+    }
+
+    /// Adds or replaces a single flag, emitting `.configurationChanged` for that key.
+    public func updateFlag(key: String, flag: InMemoryFlag) {
+        flagsLock.withLock { _flags[key] = flag }
+        send(flagsChanged: [key], message: "flag added/updated")
+    }
+
+    /// Removes a single flag, emitting `.configurationChanged` for that key.
+    ///
+    /// Nothing is emitted when the flag was not present.
+    public func removeFlag(key: String) {
+        let existed = flagsLock.withLock { _flags.removeValue(forKey: key) != nil }
+        guard existed else { return }
+        send(flagsChanged: [key], message: "flag removed")
+    }
+
+    private func send(flagsChanged: [String], message: String) {
+        statusTracker.send(
+            .configurationChanged(
+                ProviderEventDetails(flagsChanged: flagsChanged, message: message)))
+    }
+
+    // MARK: - Resolution
+
+    public func getBooleanEvaluation(key: String, defaultValue: Bool, context: EvaluationContext?) throws
+        -> ProviderEvaluation<Bool>
+    {
+        return try resolve(key: key, defaultValue: defaultValue, context: context) { $0.asBoolean() }
+    }
+
+    public func getStringEvaluation(key: String, defaultValue: String, context: EvaluationContext?) throws
+        -> ProviderEvaluation<String>
+    {
+        return try resolve(key: key, defaultValue: defaultValue, context: context) { $0.asString() }
+    }
+
+    public func getIntegerEvaluation(key: String, defaultValue: Int64, context: EvaluationContext?) throws
+        -> ProviderEvaluation<Int64>
+    {
+        return try resolve(key: key, defaultValue: defaultValue, context: context) { $0.asInteger() }
+    }
+
+    public func getDoubleEvaluation(key: String, defaultValue: Double, context: EvaluationContext?) throws
+        -> ProviderEvaluation<Double>
+    {
+        return try resolve(key: key, defaultValue: defaultValue, context: context) { $0.asDouble() }
+    }
+
+    public func getObjectEvaluation(key: String, defaultValue: Value, context: EvaluationContext?) throws
+        -> ProviderEvaluation<Value>
+    {
+        // Every variant already is a `Value`, so this never reports a type mismatch.
+        return try resolve(key: key, defaultValue: defaultValue, context: context) { $0 }
+    }
+
+    /// - Parameter coerce: returns `nil` when the stored variant holds a different type.
+    private func resolve<T>(
+        key: String,
+        defaultValue: T,
+        context: EvaluationContext?,
+        coerce: (Value) -> T?
+    ) throws -> ProviderEvaluation<T> {
+        // Only `.notReady` blocks evaluation: a transient `.stale` must not turn every
+        // resolution into an error.
+        guard status != .notReady else {
+            throw OpenFeatureError.providerNotReadyError
+        }
+
+        guard let flag = flags[key] else {
+            throw OpenFeatureError.flagNotFoundError(key: key)
+        }
+
+        if flag.disabled {
+            return ProviderEvaluation(
+                value: defaultValue,
+                flagMetadata: flag.flagMetadata,
+                reason: Reason.disabled.rawValue)
+        }
+
+        let variant: String
+        let reason: Reason
+        if let contextEvaluator = flag.contextEvaluator {
+            if let targeted = contextEvaluator(flag, context) {
+                variant = targeted
+                reason = .targetingMatch
+            } else {
+                variant = flag.defaultVariant
+                reason = .defaultReason
+            }
+        } else {
+            variant = flag.defaultVariant
+            reason = .staticReason
+        }
+
+        guard let stored = flag.variants[variant] else {
+            throw OpenFeatureError.generalError(
+                message: "Flag \"\(key)\" has no variant named \"\(variant)\"")
+        }
+
+        guard let value = coerce(stored) else {
+            throw OpenFeatureError.typeMismatchError
+        }
+
+        return ProviderEvaluation(
+            value: value,
+            flagMetadata: flag.flagMetadata,
+            variant: variant,
+            reason: reason.rawValue)
+    }
+}
+
+extension InMemoryProvider {
+    struct InMemoryProviderMetadata: ProviderMetadata {
+        var name: String? { InMemoryProvider.name }
+    }
+}

--- a/Sources/OpenFeature/Reason.swift
+++ b/Sources/OpenFeature/Reason.swift
@@ -1,9 +1,5 @@
 import Foundation
 
-/// Predefined resolution reasons.
-///
-/// Raw values are fixed by the OpenFeature specification and are compared as strings by
-/// consumers, so they cannot be changed without breaking them.
 public enum Reason: String {
     /// The resolved value is static (no dynamic evaluation).
     case staticReason = "STATIC"

--- a/Sources/OpenFeature/Reason.swift
+++ b/Sources/OpenFeature/Reason.swift
@@ -1,22 +1,26 @@
 import Foundation
 
+/// Predefined resolution reasons.
+///
+/// Raw values are fixed by the OpenFeature specification and are compared as strings by
+/// consumers, so they cannot be changed without breaking them.
 public enum Reason: String {
     /// The resolved value is static (no dynamic evaluation).
-    case staticReason
+    case staticReason = "STATIC"
     /// The resolved value was configured statically, or otherwise fell back to a pre-configured value.
-    case defaultReason
+    case defaultReason = "DEFAULT"
     /// The resolved value was the result of a dynamic evaluation, such as a rule or specific user-targeting.
-    case targetingMatch
+    case targetingMatch = "TARGETING_MATCH"
     /// The resolved value was the result of pseudorandom assignment.
-    case split
+    case split = "SPLIT"
     /// The resolved value was retrieved from cache.
-    case cached
+    case cached = "CACHED"
     /// The resolved value was the result of the flag being disabled in the management system.
-    case disabled
+    case disabled = "DISABLED"
     /// The reason for the resolved value could not be determined.
-    case unknown
+    case unknown = "UNKNOWN"
     /// The resolved value is non-authoritative or possible out of date
-    case stale
+    case stale = "STALE"
     /// The resolved value was the result of an error.
-    case error
+    case error = "ERROR"
 }

--- a/Sources/OpenFeature/Reason.swift
+++ b/Sources/OpenFeature/Reason.swift
@@ -19,7 +19,7 @@ public enum Reason: String {
     case disabled = "DISABLED"
     /// The reason for the resolved value could not be determined.
     case unknown = "UNKNOWN"
-    /// The resolved value is non-authoritative or possible out of date
+    /// The resolved value is non-authoritative or possibly out of date.
     case stale = "STALE"
     /// The resolved value was the result of an error.
     case error = "ERROR"

--- a/Sources/OpenFeature/exceptions/ErrorCode.swift
+++ b/Sources/OpenFeature/exceptions/ErrorCode.swift
@@ -1,16 +1,12 @@
 import Foundation
 
-/// Predefined error codes.
-///
-/// Raw values are fixed by the OpenFeature specification and are compared as strings by
-/// consumers, so they cannot be changed without breaking them.
-public enum ErrorCode: String {
-    case providerNotReady = "PROVIDER_NOT_READY"
-    case flagNotFound = "FLAG_NOT_FOUND"
-    case parseError = "PARSE_ERROR"
-    case typeMismatch = "TYPE_MISMATCH"
-    case targetingKeyMissing = "TARGETING_KEY_MISSING"
-    case invalidContext = "INVALID_CONTEXT"
-    case general = "GENERAL"
-    case providerFatal = "PROVIDER_FATAL"
+public enum ErrorCode: Int {
+    case providerNotReady
+    case flagNotFound
+    case parseError
+    case typeMismatch
+    case targetingKeyMissing
+    case invalidContext
+    case general
+    case providerFatal
 }

--- a/Sources/OpenFeature/exceptions/ErrorCode.swift
+++ b/Sources/OpenFeature/exceptions/ErrorCode.swift
@@ -1,12 +1,16 @@
 import Foundation
 
-public enum ErrorCode: Int {
-    case providerNotReady
-    case flagNotFound
-    case parseError
-    case typeMismatch
-    case targetingKeyMissing
-    case invalidContext
-    case general
-    case providerFatal
+/// Predefined error codes.
+///
+/// Raw values are fixed by the OpenFeature specification and are compared as strings by
+/// consumers, so they cannot be changed without breaking them.
+public enum ErrorCode: String {
+    case providerNotReady = "PROVIDER_NOT_READY"
+    case flagNotFound = "FLAG_NOT_FOUND"
+    case parseError = "PARSE_ERROR"
+    case typeMismatch = "TYPE_MISMATCH"
+    case targetingKeyMissing = "TARGETING_KEY_MISSING"
+    case invalidContext = "INVALID_CONTEXT"
+    case general = "GENERAL"
+    case providerFatal = "PROVIDER_FATAL"
 }

--- a/Tests/OpenFeatureTests/Helpers/InMemoryTestFlags.swift
+++ b/Tests/OpenFeatureTests/Helpers/InMemoryTestFlags.swift
@@ -1,0 +1,77 @@
+import Foundation
+import OpenFeature
+
+/// Flag configuration shared by the `InMemoryProvider` test cases.
+enum InMemoryTestFlags {
+    static let templateVariant: Value = .structure([
+        "showImages": .boolean(true),
+        "title": .string("Check out these pics!"),
+        "imagesPerPage": .integer(100),
+    ])
+
+    static let metadata: FlagMetadata = [
+        "string": .string("1.0.2"),
+        "integer": .integer(2),
+        "boolean": .boolean(true),
+        "double": .double(0.1),
+    ]
+
+    static let contextAwareEvaluator: InMemoryFlag.ContextEvaluator = { _, context in
+        context?.getValue(key: "customer") == .boolean(false) ? "internal" : nil
+    }
+
+    static func all() -> [String: InMemoryFlag] {
+        return [
+            "boolean-flag": InMemoryFlag(
+                variants: ["on": .boolean(true), "off": .boolean(false)],
+                defaultVariant: "on"),
+            "string-flag": InMemoryFlag(
+                variants: ["greeting": .string("hi"), "parting": .string("bye")],
+                defaultVariant: "greeting"),
+            "integer-flag": InMemoryFlag(
+                variants: ["one": .integer(1), "ten": .integer(10)],
+                defaultVariant: "ten"),
+            "float-flag": InMemoryFlag(
+                variants: ["tenth": .double(0.1), "half": .double(0.5)],
+                defaultVariant: "half"),
+            "object-flag": InMemoryFlag(
+                variants: ["empty": .structure([:]), "template": templateVariant],
+                defaultVariant: "template"),
+            "metadata-flag": InMemoryFlag(
+                variants: ["on": .boolean(true), "off": .boolean(false)],
+                defaultVariant: "on",
+                flagMetadata: metadata),
+            "disabled-flag": InMemoryFlag(
+                variants: ["on": .boolean(true), "off": .boolean(false)],
+                defaultVariant: "on",
+                flagMetadata: metadata,
+                disabled: true),
+            "missing-variant-flag": InMemoryFlag(
+                variants: ["on": .boolean(true)],
+                defaultVariant: "nope"),
+            "context-aware": InMemoryFlag(
+                variants: ["internal": .string("INTERNAL"), "external": .string("EXTERNAL")],
+                defaultVariant: "external",
+                contextEvaluator: contextAwareEvaluator),
+        ]
+    }
+
+    static func single(key: String) -> [String: InMemoryFlag] {
+        return [key: InMemoryFlag(variants: ["on": .boolean(true)], defaultVariant: "on")]
+    }
+
+    static func enabledFlag() -> InMemoryFlag {
+        return InMemoryFlag(variants: ["on": .boolean(true)], defaultVariant: "on")
+    }
+
+    /// Already through `initialize`, without going through `OpenFeatureAPI`.
+    static func readyProvider(flags: [String: InMemoryFlag]? = nil) -> InMemoryProvider {
+        let provider = InMemoryProvider(flags: flags ?? all())
+        _ = provider.initialize(initialContext: nil)
+        return provider
+    }
+
+    static func internalCustomerContext() -> MutableContext {
+        return MutableContext(targetingKey: "user-1").add(key: "customer", value: .boolean(false))
+    }
+}

--- a/Tests/OpenFeatureTests/InMemoryProviderErrorTests.swift
+++ b/Tests/OpenFeatureTests/InMemoryProviderErrorTests.swift
@@ -1,0 +1,120 @@
+import Foundation
+import OpenFeature
+import XCTest
+
+/// Error paths of `InMemoryProvider`, and how the client surfaces them.
+final class InMemoryProviderErrorTests: XCTestCase {
+    override func tearDown() {
+        OpenFeatureAPI.shared.clearProvider()
+        super.tearDown()
+    }
+
+    private func assertThrows(
+        _ expected: ErrorCode,
+        _ expression: () throws -> Void,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        XCTAssertThrowsError(try expression(), file: file, line: line) { error in
+            XCTAssertEqual((error as? OpenFeatureError)?.errorCode(), expected, file: file, line: line)
+        }
+    }
+
+    // MARK: - Provider errors
+
+    func testUnknownFlagKeyThrowsFlagNotFound() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        assertThrows(.flagNotFound) {
+            _ = try provider.getStringEvaluation(key: "missing-flag", defaultValue: "uh-oh", context: nil)
+        }
+    }
+
+    func testStringFlagEvaluatedAsIntegerThrowsTypeMismatch() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        assertThrows(.typeMismatch) {
+            _ = try provider.getIntegerEvaluation(key: "string-flag", defaultValue: 13, context: nil)
+        }
+    }
+
+    func testIntegerVariantEvaluatedAsDoubleThrowsTypeMismatch() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        assertThrows(.typeMismatch) {
+            _ = try provider.getDoubleEvaluation(key: "integer-flag", defaultValue: 0.1, context: nil)
+        }
+    }
+
+    func testDoubleVariantEvaluatedAsIntegerThrowsTypeMismatch() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        assertThrows(.typeMismatch) {
+            _ = try provider.getIntegerEvaluation(key: "float-flag", defaultValue: 1, context: nil)
+        }
+    }
+
+    func testScalarFlagEvaluatedAsObjectPassesTheVariantThrough() throws {
+        let result = try InMemoryTestFlags.readyProvider().getObjectEvaluation(
+            key: "boolean-flag", defaultValue: .null, context: nil)
+
+        XCTAssertEqual(result.value, .boolean(true))
+        XCTAssertEqual(result.reason, "STATIC")
+    }
+
+    func testEvaluationBeforeInitializeThrowsProviderNotReady() {
+        let provider = InMemoryProvider(flags: InMemoryTestFlags.all())
+        XCTAssertEqual(provider.status, .notReady)
+
+        assertThrows(.providerNotReady) {
+            _ = try provider.getBooleanEvaluation(key: "boolean-flag", defaultValue: false, context: nil)
+        }
+    }
+
+    func testDefaultVariantMissingFromVariantsThrowsGeneralError() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        assertThrows(.general) {
+            _ = try provider.getBooleanEvaluation(
+                key: "missing-variant-flag", defaultValue: false, context: nil)
+        }
+    }
+
+    func testContextEvaluatorReturningUnknownVariantThrowsGeneralError() {
+        let evaluator: InMemoryFlag.ContextEvaluator = { _, _ in "nope" }
+        let flag = InMemoryFlag(
+            variants: ["on": .boolean(true)], defaultVariant: "on", contextEvaluator: evaluator)
+        let provider = InMemoryTestFlags.readyProvider(flags: ["bad-targeting": flag])
+
+        assertThrows(.general) {
+            _ = try provider.getBooleanEvaluation(key: "bad-targeting", defaultValue: false, context: nil)
+        }
+    }
+
+    // MARK: - Client mapping
+
+    func testClientMapsFlagNotFoundToDetailsWithFallbackValue() async {
+        await OpenFeatureAPI.shared.setProviderAndWait(
+            provider: InMemoryProvider(flags: InMemoryTestFlags.all()))
+
+        let details = OpenFeatureAPI.shared.getClient().getStringDetails(
+            key: "missing-flag", defaultValue: "uh-oh")
+
+        XCTAssertEqual(details.value, "uh-oh")
+        XCTAssertEqual(details.reason, "ERROR")
+        XCTAssertEqual(details.errorCode, .flagNotFound)
+        XCTAssertNil(details.variant)
+    }
+
+    func testClientMapsTypeMismatchToDetailsWithFallbackValue() async {
+        await OpenFeatureAPI.shared.setProviderAndWait(
+            provider: InMemoryProvider(flags: InMemoryTestFlags.all()))
+
+        let details = OpenFeatureAPI.shared.getClient().getIntegerDetails(
+            key: "string-flag", defaultValue: 13)
+
+        XCTAssertEqual(details.value, 13)
+        XCTAssertEqual(details.reason, "ERROR")
+        XCTAssertEqual(details.errorCode, .typeMismatch)
+    }
+}

--- a/Tests/OpenFeatureTests/InMemoryProviderErrorTests.swift
+++ b/Tests/OpenFeatureTests/InMemoryProviderErrorTests.swift
@@ -54,12 +54,12 @@ final class InMemoryProviderErrorTests: XCTestCase {
         }
     }
 
-    func testScalarFlagEvaluatedAsObjectPassesTheVariantThrough() throws {
-        let result = try InMemoryTestFlags.readyProvider().getObjectEvaluation(
-            key: "boolean-flag", defaultValue: .null, context: nil)
+    func testScalarFlagEvaluatedAsObjectThrowsTypeMismatch() {
+        let provider = InMemoryTestFlags.readyProvider()
 
-        XCTAssertEqual(result.value, .boolean(true))
-        XCTAssertEqual(result.reason, "STATIC")
+        assertThrows(.typeMismatch) {
+            _ = try provider.getObjectEvaluation(key: "boolean-flag", defaultValue: .null, context: nil)
+        }
     }
 
     func testEvaluationBeforeInitializeThrowsProviderNotReady() {

--- a/Tests/OpenFeatureTests/InMemoryProviderEventTests.swift
+++ b/Tests/OpenFeatureTests/InMemoryProviderEventTests.swift
@@ -1,0 +1,218 @@
+import Combine
+import Foundation
+import OpenFeature
+import XCTest
+
+/// Configuration mutation, `.configurationChanged` emission, lifecycle events, and concurrency.
+final class InMemoryProviderEventTests: XCTestCase {
+    // MARK: - Configuration mutation
+
+    func testPutConfigurationEmitsUnionOfPreviousAndNewFlagKeys() {
+        let provider = InMemoryTestFlags.readyProvider(flags: [
+            "kept": InMemoryTestFlags.enabledFlag(),
+            "removed": InMemoryTestFlags.enabledFlag(),
+        ])
+
+        let details = expectConfigurationChanged(from: provider) {
+            provider.putConfiguration([
+                "kept": InMemoryTestFlags.enabledFlag(),
+                "added": InMemoryTestFlags.enabledFlag(),
+            ])
+        }
+
+        XCTAssertEqual(details?.flagsChanged, ["added", "kept", "removed"])
+    }
+
+    func testPutConfigurationReplacesConfiguration() throws {
+        let provider = InMemoryTestFlags.readyProvider()
+        provider.putConfiguration(InMemoryTestFlags.single(key: "only-flag"))
+
+        XCTAssertEqual(
+            try provider.getBooleanEvaluation(key: "only-flag", defaultValue: false, context: nil).value,
+            true)
+        XCTAssertThrowsError(
+            try provider.getBooleanEvaluation(key: "boolean-flag", defaultValue: false, context: nil)
+        ) { error in
+            XCTAssertEqual((error as? OpenFeatureError)?.errorCode(), .flagNotFound)
+        }
+    }
+
+    func testUpdateFlagEmitsSingleKeyAndIsResolvableImmediately() throws {
+        let provider = InMemoryTestFlags.readyProvider(flags: [:])
+
+        let details = expectConfigurationChanged(from: provider) {
+            provider.updateFlag(key: "new-flag", flag: InMemoryTestFlags.enabledFlag())
+        }
+
+        XCTAssertEqual(details?.flagsChanged, ["new-flag"])
+        XCTAssertEqual(
+            try provider.getBooleanEvaluation(key: "new-flag", defaultValue: false, context: nil).value,
+            true)
+    }
+
+    func testRemoveFlagEmitsSingleKeyAndSubsequentEvaluationThrowsFlagNotFound() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        let details = expectConfigurationChanged(from: provider) {
+            provider.removeFlag(key: "boolean-flag")
+        }
+
+        XCTAssertEqual(details?.flagsChanged, ["boolean-flag"])
+        XCTAssertThrowsError(
+            try provider.getBooleanEvaluation(key: "boolean-flag", defaultValue: false, context: nil)
+        ) { error in
+            XCTAssertEqual((error as? OpenFeatureError)?.errorCode(), .flagNotFound)
+        }
+    }
+
+    func testRemoveFlagForUnknownKeyEmitsNoEvent() {
+        let provider = InMemoryTestFlags.readyProvider()
+        var changedKeys: [[String]?] = []
+        let expectation = XCTestExpectation(description: "sentinel configurationChanged emitted")
+        let cancellable = provider.observe().sink { event in
+            if case .configurationChanged(let details) = event {
+                changedKeys.append(details?.flagsChanged)
+                expectation.fulfill()
+            }
+        }
+        defer { cancellable.cancel() }
+
+        provider.removeFlag(key: "not-a-flag")
+        // Waiting on a sentinel mutation, rather than asserting synchronously, gives the no-op
+        // above a chance to emit: events are delivered in order on a serial queue.
+        provider.removeFlag(key: "boolean-flag")
+
+        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 5), .completed)
+        XCTAssertEqual(changedKeys, [["boolean-flag"]])
+    }
+
+    func testConfigurationChangedDoesNotChangeProviderStatus() {
+        let provider = InMemoryTestFlags.readyProvider()
+        XCTAssertEqual(provider.status, .ready)
+
+        provider.putConfiguration([:])
+
+        XCTAssertEqual(provider.status, .ready)
+    }
+
+    func testConfigurationChangedIsObservableThroughOpenFeatureAPI() async {
+        let api = OpenFeatureAPI()
+        let provider = InMemoryProvider(flags: InMemoryTestFlags.all())
+        await api.setProviderAndWait(provider: provider)
+
+        let expectation = XCTestExpectation(description: "configurationChanged observed")
+        var observed: ProviderEventDetails?
+        let cancellable = api.observe().sink { event in
+            if case .configurationChanged(let details) = event {
+                observed = details
+                expectation.fulfill()
+            }
+        }
+        defer { cancellable.cancel() }
+
+        provider.updateFlag(key: "late-flag", flag: InMemoryTestFlags.enabledFlag())
+
+        await fulfillment(of: [expectation], timeout: 5)
+        XCTAssertEqual(observed?.flagsChanged, ["late-flag"])
+    }
+
+    // MARK: - Lifecycle
+
+    func testInitializeEmitsReadyAndSetsStatusReady() {
+        let provider = InMemoryProvider(flags: InMemoryTestFlags.all())
+        XCTAssertEqual(provider.status, .notReady)
+
+        expectEvent(from: provider, description: "ready emitted") { event in
+            event == .ready(nil)
+        } mutate: {
+            _ = provider.initialize(initialContext: nil)
+        }
+
+        XCTAssertEqual(provider.status, .ready)
+    }
+
+    func testOnContextSetEmitsContextChangedAndKeepsStatusReady() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        expectEvent(from: provider, description: "contextChanged emitted") { event in
+            event == .contextChanged(nil)
+        } mutate: {
+            _ = provider.onContextSet(oldContext: nil, newContext: MutableContext())
+        }
+
+        XCTAssertEqual(provider.status, .ready)
+    }
+
+    // MARK: - Concurrency
+
+    func testConcurrentEvaluationsAndConfigurationUpdatesAreSafe() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        DispatchQueue.concurrentPerform(iterations: 100) { iteration in
+            if iteration.isMultiple(of: 10) {
+                provider.putConfiguration(InMemoryTestFlags.all())
+            } else {
+                _ = try? provider.getBooleanEvaluation(
+                    key: "boolean-flag", defaultValue: false, context: nil)
+            }
+        }
+
+        XCTAssertEqual(provider.status, .ready)
+    }
+
+    func testConfigurationChangedSubscriberCallingBackIntoProviderDoesNotDeadlock() {
+        let provider = InMemoryTestFlags.readyProvider(flags: [:])
+        let expectation = XCTestExpectation(description: "reentrant subscriber returned")
+
+        let cancellable = provider.observe().sink { event in
+            guard case .configurationChanged = event else { return }
+            _ = provider.flags
+            expectation.fulfill()
+        }
+        defer { cancellable.cancel() }
+
+        provider.updateFlag(key: "flag", flag: InMemoryTestFlags.enabledFlag())
+
+        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 5), .completed)
+    }
+
+    // MARK: - Helpers
+
+    /// Events are delivered on a serial queue, so they cannot be asserted on synchronously after
+    /// the call that emits them.
+    private func expectEvent(
+        from provider: InMemoryProvider,
+        description: String,
+        matching predicate: @escaping (ProviderEvent) -> Bool,
+        mutate: () -> Void
+    ) {
+        let expectation = XCTestExpectation(description: description)
+        let cancellable = provider.observe().sink { event in
+            if predicate(event) {
+                expectation.fulfill()
+            }
+        }
+        defer { cancellable.cancel() }
+
+        mutate()
+
+        XCTAssertEqual(XCTWaiter().wait(for: [expectation], timeout: 5), .completed, description)
+    }
+
+    private func expectConfigurationChanged(
+        from provider: InMemoryProvider,
+        _ mutate: () -> Void
+    ) -> ProviderEventDetails? {
+        var details: ProviderEventDetails?
+        expectEvent(from: provider, description: "configurationChanged emitted") { event in
+            if case .configurationChanged(let eventDetails) = event {
+                details = eventDetails
+                return true
+            }
+            return false
+        } mutate: {
+            mutate()
+        }
+        return details
+    }
+}

--- a/Tests/OpenFeatureTests/InMemoryProviderTargetingTests.swift
+++ b/Tests/OpenFeatureTests/InMemoryProviderTargetingTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import OpenFeature
+import XCTest
+
+/// `InMemoryFlag.contextEvaluator` behaviour.
+final class InMemoryProviderTargetingTests: XCTestCase {
+    override func tearDown() {
+        OpenFeatureAPI.shared.clearProvider()
+        super.tearDown()
+    }
+
+    func testContextEvaluatorResolvesTargetedVariantWithTargetingMatch() throws {
+        let result = try InMemoryTestFlags.readyProvider().getStringEvaluation(
+            key: "context-aware",
+            defaultValue: "EXTERNAL",
+            context: InMemoryTestFlags.internalCustomerContext())
+
+        XCTAssertEqual(result.value, "INTERNAL")
+        XCTAssertEqual(result.variant, "internal")
+        XCTAssertEqual(result.reason, "TARGETING_MATCH")
+    }
+
+    func testContextEvaluatorReturningNilFallsBackToDefaultVariant() throws {
+        let result = try InMemoryTestFlags.readyProvider().getStringEvaluation(
+            key: "context-aware", defaultValue: "fallback", context: MutableContext())
+
+        XCTAssertEqual(result.value, "EXTERNAL")
+        XCTAssertEqual(result.variant, "external")
+        XCTAssertEqual(result.reason, "DEFAULT")
+    }
+
+    func testFlagWithoutContextEvaluatorUsesStaticReason() throws {
+        let result = try InMemoryTestFlags.readyProvider().getBooleanEvaluation(
+            key: "boolean-flag",
+            defaultValue: false,
+            context: InMemoryTestFlags.internalCustomerContext())
+
+        XCTAssertEqual(result.reason, "STATIC")
+    }
+
+    func testContextEvaluatorRunsWithNilContext() throws {
+        var sawNilContext = false
+        let evaluator: InMemoryFlag.ContextEvaluator = { _, context in
+            sawNilContext = context == nil
+            return nil
+        }
+        let flag = InMemoryFlag(
+            variants: ["on": .boolean(true)], defaultVariant: "on", contextEvaluator: evaluator)
+        let provider = InMemoryTestFlags.readyProvider(flags: ["probe": flag])
+
+        _ = try provider.getBooleanEvaluation(key: "probe", defaultValue: false, context: nil)
+
+        XCTAssertTrue(sawNilContext)
+    }
+
+    func testContextEvaluatorReceivesTheFlagItIsResolving() throws {
+        var seenVariantCount = 0
+        let evaluator: InMemoryFlag.ContextEvaluator = { flag, _ in
+            seenVariantCount = flag.variants.count
+            return nil
+        }
+        let flag = InMemoryFlag(
+            variants: ["on": .boolean(true), "off": .boolean(false)],
+            defaultVariant: "on",
+            contextEvaluator: evaluator)
+        let provider = InMemoryTestFlags.readyProvider(flags: ["probe": flag])
+
+        _ = try provider.getBooleanEvaluation(key: "probe", defaultValue: false, context: nil)
+
+        XCTAssertEqual(seenVariantCount, 2)
+    }
+
+    func testContextEvaluatorResultIsTypeChecked() {
+        let provider = InMemoryTestFlags.readyProvider()
+
+        XCTAssertThrowsError(
+            try provider.getBooleanEvaluation(
+                key: "context-aware",
+                defaultValue: false,
+                context: InMemoryTestFlags.internalCustomerContext())
+        ) { error in
+            XCTAssertEqual((error as? OpenFeatureError)?.errorCode(), .typeMismatch)
+        }
+    }
+
+    func testEvaluationUsesContextSetOnOpenFeatureAPI() async {
+        await OpenFeatureAPI.shared.setProviderAndWait(
+            provider: InMemoryProvider(flags: InMemoryTestFlags.all()))
+        let client = OpenFeatureAPI.shared.getClient()
+
+        XCTAssertEqual(client.getStringValue(key: "context-aware", defaultValue: "fallback"), "EXTERNAL")
+
+        await OpenFeatureAPI.shared.setEvaluationContextAndWait(
+            evaluationContext: InMemoryTestFlags.internalCustomerContext())
+
+        XCTAssertEqual(client.getStringValue(key: "context-aware", defaultValue: "fallback"), "INTERNAL")
+    }
+}

--- a/Tests/OpenFeatureTests/InMemoryProviderTests.swift
+++ b/Tests/OpenFeatureTests/InMemoryProviderTests.swift
@@ -1,0 +1,124 @@
+import Foundation
+import OpenFeature
+import XCTest
+
+/// Resolution of the five flag types, flag metadata, and disabled flags.
+final class InMemoryProviderTests: XCTestCase {
+    override func tearDown() {
+        OpenFeatureAPI.shared.clearProvider()
+        super.tearDown()
+    }
+
+    // MARK: - Resolution
+
+    func testBooleanEvaluationResolvesDefaultVariant() throws {
+        let result = try InMemoryTestFlags.readyProvider().getBooleanEvaluation(
+            key: "boolean-flag", defaultValue: false, context: nil)
+
+        XCTAssertEqual(result.value, true)
+        XCTAssertEqual(result.variant, "on")
+        XCTAssertEqual(result.reason, "STATIC")
+        XCTAssertNil(result.errorCode)
+    }
+
+    func testStringEvaluationResolvesDefaultVariant() throws {
+        let result = try InMemoryTestFlags.readyProvider().getStringEvaluation(
+            key: "string-flag", defaultValue: "bye", context: nil)
+
+        XCTAssertEqual(result.value, "hi")
+        XCTAssertEqual(result.variant, "greeting")
+        XCTAssertEqual(result.reason, "STATIC")
+    }
+
+    func testIntegerEvaluationResolvesDefaultVariant() throws {
+        let result = try InMemoryTestFlags.readyProvider().getIntegerEvaluation(
+            key: "integer-flag", defaultValue: 1, context: nil)
+
+        XCTAssertEqual(result.value, 10)
+        XCTAssertEqual(result.variant, "ten")
+        XCTAssertEqual(result.reason, "STATIC")
+    }
+
+    func testDoubleEvaluationResolvesDefaultVariant() throws {
+        let result = try InMemoryTestFlags.readyProvider().getDoubleEvaluation(
+            key: "float-flag", defaultValue: 0.1, context: nil)
+
+        XCTAssertEqual(result.value, 0.5)
+        XCTAssertEqual(result.variant, "half")
+        XCTAssertEqual(result.reason, "STATIC")
+    }
+
+    func testObjectEvaluationResolvesStructureVariant() throws {
+        let result = try InMemoryTestFlags.readyProvider().getObjectEvaluation(
+            key: "object-flag", defaultValue: .null, context: nil)
+
+        XCTAssertEqual(result.value, InMemoryTestFlags.templateVariant)
+        XCTAssertEqual(result.variant, "template")
+        XCTAssertEqual(result.reason, "STATIC")
+    }
+
+    func testEvaluationCarriesFlagMetadata() throws {
+        let result = try InMemoryTestFlags.readyProvider().getBooleanEvaluation(
+            key: "metadata-flag", defaultValue: false, context: nil)
+
+        XCTAssertEqual(result.flagMetadata["string"], .string("1.0.2"))
+        XCTAssertEqual(result.flagMetadata["integer"], .integer(2))
+        XCTAssertEqual(result.flagMetadata["boolean"], .boolean(true))
+        XCTAssertEqual(result.flagMetadata["double"], .double(0.1))
+    }
+
+    func testEvaluationWithoutFlagMetadataYieldsEmptyMetadata() throws {
+        let result = try InMemoryTestFlags.readyProvider().getBooleanEvaluation(
+            key: "boolean-flag", defaultValue: false, context: nil)
+
+        XCTAssertTrue(result.flagMetadata.isEmpty)
+    }
+
+    func testEvaluationThroughClientResolvesEveryType() async {
+        await OpenFeatureAPI.shared.setProviderAndWait(
+            provider: InMemoryProvider(flags: InMemoryTestFlags.all()))
+        let client = OpenFeatureAPI.shared.getClient()
+
+        XCTAssertEqual(client.getBooleanValue(key: "boolean-flag", defaultValue: false), true)
+        XCTAssertEqual(client.getStringValue(key: "string-flag", defaultValue: "bye"), "hi")
+        XCTAssertEqual(client.getIntegerValue(key: "integer-flag", defaultValue: 1), 10)
+        XCTAssertEqual(client.getDoubleValue(key: "float-flag", defaultValue: 0.1), 0.5)
+        XCTAssertEqual(
+            client.getObjectValue(key: "object-flag", defaultValue: .null),
+            InMemoryTestFlags.templateVariant)
+    }
+
+    // MARK: - Disabled flags
+
+    func testDisabledFlagReturnsCallerDefaultWithDisabledReason() throws {
+        let result = try InMemoryTestFlags.readyProvider().getBooleanEvaluation(
+            key: "disabled-flag", defaultValue: false, context: nil)
+
+        XCTAssertEqual(result.value, false)
+        XCTAssertEqual(result.reason, "DISABLED")
+        XCTAssertNil(result.variant)
+        XCTAssertNil(result.errorCode)
+    }
+
+    func testDisabledFlagStillReturnsFlagMetadata() throws {
+        let result = try InMemoryTestFlags.readyProvider().getBooleanEvaluation(
+            key: "disabled-flag", defaultValue: false, context: nil)
+
+        XCTAssertEqual(result.flagMetadata["string"], .string("1.0.2"))
+    }
+
+    // MARK: - Metadata
+
+    func testMetadataNameAndHooks() {
+        let provider = InMemoryProvider()
+
+        XCTAssertEqual(provider.metadata.name, "InMemoryProvider")
+        XCTAssertTrue(provider.hooks.isEmpty)
+    }
+
+    func testFlagsSnapshotReflectsConstructorConfiguration() {
+        let provider = InMemoryProvider(flags: InMemoryTestFlags.all())
+
+        XCTAssertEqual(Set(provider.flags.keys), Set(InMemoryTestFlags.all().keys))
+    }
+}

--- a/Tests/OpenFeatureTests/ProviderSpecTests.swift
+++ b/Tests/OpenFeatureTests/ProviderSpecTests.swift
@@ -27,7 +27,7 @@ final class ProviderSpecTests: XCTestCase {
         let provider = NoOpProvider()
 
         let boolResult = try provider.getBooleanEvaluation(key: "key", defaultValue: false, context: MutableContext())
-        XCTAssertEqual(boolResult.reason, Reason.defaultReason.rawValue)
+        XCTAssertEqual(boolResult.reason, "DEFAULT")
     }
 
     func testNoErrorCodeByDefault() throws {

--- a/Tests/OpenFeatureTests/ReasonTests.swift
+++ b/Tests/OpenFeatureTests/ReasonTests.swift
@@ -2,8 +2,6 @@ import Foundation
 import OpenFeature
 import XCTest
 
-/// Asserts the literal strings, because assertions elsewhere compare `details.reason` against
-/// `Reason.x.rawValue` and so pass for any value.
 final class ReasonTests: XCTestCase {
     func testReasonRawValuesMatchSpecification() {
         XCTAssertEqual(Reason.staticReason.rawValue, "STATIC")

--- a/Tests/OpenFeatureTests/ReasonTests.swift
+++ b/Tests/OpenFeatureTests/ReasonTests.swift
@@ -1,0 +1,30 @@
+import Foundation
+import OpenFeature
+import XCTest
+
+/// Asserts the literal raw values, because assertions elsewhere compare `details.reason` against
+/// `Reason.x.rawValue` and so pass for any value.
+final class ReasonTests: XCTestCase {
+    func testReasonRawValuesMatchSpecification() {
+        XCTAssertEqual(Reason.staticReason.rawValue, "STATIC")
+        XCTAssertEqual(Reason.defaultReason.rawValue, "DEFAULT")
+        XCTAssertEqual(Reason.targetingMatch.rawValue, "TARGETING_MATCH")
+        XCTAssertEqual(Reason.split.rawValue, "SPLIT")
+        XCTAssertEqual(Reason.cached.rawValue, "CACHED")
+        XCTAssertEqual(Reason.disabled.rawValue, "DISABLED")
+        XCTAssertEqual(Reason.unknown.rawValue, "UNKNOWN")
+        XCTAssertEqual(Reason.stale.rawValue, "STALE")
+        XCTAssertEqual(Reason.error.rawValue, "ERROR")
+    }
+
+    func testErrorCodeRawValuesMatchSpecification() {
+        XCTAssertEqual(ErrorCode.providerNotReady.rawValue, "PROVIDER_NOT_READY")
+        XCTAssertEqual(ErrorCode.flagNotFound.rawValue, "FLAG_NOT_FOUND")
+        XCTAssertEqual(ErrorCode.parseError.rawValue, "PARSE_ERROR")
+        XCTAssertEqual(ErrorCode.typeMismatch.rawValue, "TYPE_MISMATCH")
+        XCTAssertEqual(ErrorCode.targetingKeyMissing.rawValue, "TARGETING_KEY_MISSING")
+        XCTAssertEqual(ErrorCode.invalidContext.rawValue, "INVALID_CONTEXT")
+        XCTAssertEqual(ErrorCode.general.rawValue, "GENERAL")
+        XCTAssertEqual(ErrorCode.providerFatal.rawValue, "PROVIDER_FATAL")
+    }
+}

--- a/Tests/OpenFeatureTests/ReasonTests.swift
+++ b/Tests/OpenFeatureTests/ReasonTests.swift
@@ -2,7 +2,7 @@ import Foundation
 import OpenFeature
 import XCTest
 
-/// Asserts the literal raw values, because assertions elsewhere compare `details.reason` against
+/// Asserts the literal strings, because assertions elsewhere compare `details.reason` against
 /// `Reason.x.rawValue` and so pass for any value.
 final class ReasonTests: XCTestCase {
     func testReasonRawValuesMatchSpecification() {
@@ -15,16 +15,5 @@ final class ReasonTests: XCTestCase {
         XCTAssertEqual(Reason.unknown.rawValue, "UNKNOWN")
         XCTAssertEqual(Reason.stale.rawValue, "STALE")
         XCTAssertEqual(Reason.error.rawValue, "ERROR")
-    }
-
-    func testErrorCodeRawValuesMatchSpecification() {
-        XCTAssertEqual(ErrorCode.providerNotReady.rawValue, "PROVIDER_NOT_READY")
-        XCTAssertEqual(ErrorCode.flagNotFound.rawValue, "FLAG_NOT_FOUND")
-        XCTAssertEqual(ErrorCode.parseError.rawValue, "PARSE_ERROR")
-        XCTAssertEqual(ErrorCode.typeMismatch.rawValue, "TYPE_MISMATCH")
-        XCTAssertEqual(ErrorCode.targetingKeyMissing.rawValue, "TARGETING_KEY_MISSING")
-        XCTAssertEqual(ErrorCode.invalidContext.rawValue, "INVALID_CONTEXT")
-        XCTAssertEqual(ErrorCode.general.rawValue, "GENERAL")
-        XCTAssertEqual(ErrorCode.providerFatal.rawValue, "PROVIDER_FATAL")
     }
 }

--- a/e2e/Package.resolved
+++ b/e2e/Package.resolved
@@ -1,0 +1,33 @@
+{
+  "originHash" : "d09792752e24dd2cd894713a953414dad867bed8a9c2407f95ccaf570b56b308",
+  "pins" : [
+    {
+      "identity" : "cucumberswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/cucumberswift/CucumberSwift.git",
+      "state" : {
+        "revision" : "1d16dcd943a35eb8ecf274caf85ea827b4018d4d",
+        "version" : "5.0.10"
+      }
+    },
+    {
+      "identity" : "cucumberswiftexpressions",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/cucumberswift/CucumberSwiftExpressions.git",
+      "state" : {
+        "revision" : "5200dc2c5d7cd31f07a13f030ab0027224d2dbea",
+        "version" : "0.0.8"
+      }
+    },
+    {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log",
+      "state" : {
+        "revision" : "3ffafb9722d5d918c614feb496c8789a3b59d222",
+        "version" : "1.15.0"
+      }
+    }
+  ],
+  "version" : 3
+}

--- a/e2e/Package.swift
+++ b/e2e/Package.swift
@@ -1,0 +1,35 @@
+// swift-tools-version:5.10
+// Separate from the root OpenFeature package because CucumberSwift has no watchOS support and
+// would otherwise land in every consumer's dependency graph. Run with `../scripts/e2e`.
+
+import PackageDescription
+
+let package = Package(
+    name: "OpenFeatureE2E",
+    platforms: [
+        .iOS(.v15),
+        .macOS(.v12),
+        .tvOS(.v15),
+    ],
+    dependencies: [
+        // `name:` pins the identity to "OpenFeature"; without it it comes from the checkout
+        // directory name.
+        .package(name: "OpenFeature", path: ".."),
+        .package(url: "https://github.com/cucumberswift/CucumberSwift.git", from: "5.0.10"),
+    ],
+    targets: [
+        .testTarget(
+            name: "OpenFeatureE2ETests",
+            dependencies: [
+                .product(name: "OpenFeature", package: "OpenFeature"),
+                "CucumberSwift",
+            ],
+            resources: [
+                // .copy, not .process: .process flattens directories, and CucumberSwift resolves
+                // features via `bundle.url(forResource: "Features", withExtension: nil)`. The
+                // feature files are gitignored; a committed .gitkeep keeps this path resolvable.
+                .copy("Features"),
+            ]
+        ),
+    ]
+)

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -1,0 +1,14 @@
+# End-to-end tests
+
+Runs the OpenFeature specification's shared [`evaluation.feature`](https://github.com/open-feature/spec/blob/main/specification/assets/gherkin/evaluation.feature)
+against `InMemoryProvider` using [CucumberSwift](https://github.com/cucumberswift/CucumberSwift),
+driving the public `OpenFeatureAPI` and `Client` API with no mocks or stubs.
+
+Run it from the repository root:
+
+```shell
+./scripts/e2e
+```
+
+See [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for details, and `Tests/OpenFeatureE2ETests/Steps/EvaluationPatterns.swift`
+for the step-to-pattern mapping.

--- a/e2e/Tests/OpenFeatureE2ETests/EvaluationStepImplementation.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/EvaluationStepImplementation.swift
@@ -1,0 +1,29 @@
+import CucumberSwift
+import Foundation
+import XCTest
+
+/// CucumberSwift entry point.
+///
+/// `shouldRunWith(scenario:tags:)` is deliberately not implemented: `evaluation.feature` is tagged
+/// `@deprecated`, and tag filtering only consults that method when it exists, so implementing it
+/// without allowing `deprecated` would silently run zero scenarios.
+extension Cucumber: @retroactive StepImplementation {
+    /// Not `Bundle(for:)`: under SwiftPM the copied resources live in a sibling bundle.
+    public var bundle: Bundle { .module }
+
+    @available(
+        *, deprecated,
+        message: """
+            Registers steps through CucumberSwift's deprecated regex API. Migrate to Regex \
+            literals once the SDK's minimum platforms reach iOS 16 / macOS 13.
+            """
+    )
+    public func setupSteps() {
+        registerLifecycleHooks()
+        registerProviderSteps()
+        registerValueSteps()
+        registerDetailsSteps()
+        registerContextSteps()
+        registerErrorSteps()
+    }
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Features/.gitignore
+++ b/e2e/Tests/OpenFeatureE2ETests/Features/.gitignore
@@ -1,0 +1,1 @@
+*.feature

--- a/e2e/Tests/OpenFeatureE2ETests/Steps/ContextSteps.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Steps/ContextSteps.swift
@@ -1,0 +1,51 @@
+import CucumberSwift
+import Foundation
+import OpenFeature
+import XCTest
+
+extension Cucumber {
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    func registerContextSteps() {
+        when(EvaluationPatterns.contextContainsKeys) { matches, _ in
+            // `Client` takes no per-evaluation context, so the context is installed globally.
+            let attributes: [String: Value] = [
+                capture(matches, 1): GherkinArguments.boolOrString(capture(matches, 5)),
+                capture(matches, 2): GherkinArguments.boolOrString(capture(matches, 6)),
+                capture(matches, 3): .integer(GherkinArguments.integer(capture(matches, 7))),
+                capture(matches, 4): GherkinArguments.boolOrString(capture(matches, 8)),
+            ]
+            AsyncBridge.run {
+                await OpenFeatureAPI.shared.setEvaluationContextAndWait(
+                    evaluationContext: ImmutableContext(attributes: attributes))
+            }
+        }
+
+        // An `And` step whose primary keyword is When. Untyped in the Gherkin, a string here.
+        when(EvaluationPatterns.untypedFlagValue) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.stringValue = OpenFeatureAPI.shared.getClient().getStringValue(
+                key: capture(matches, 1), defaultValue: capture(matches, 2))
+        }
+
+        then(EvaluationPatterns.stringResponse) { matches, _ in
+            XCTAssertEqual(ScenarioState.current.stringValue, capture(matches, 1))
+        }
+
+        then(EvaluationPatterns.emptyContextValue) { matches, _ in
+            guard let flagKey = ScenarioState.current.flagKey else {
+                XCTFail("no flag was evaluated earlier in this scenario")
+                return
+            }
+            AsyncBridge.run {
+                await OpenFeatureAPI.shared.setEvaluationContextAndWait(
+                    evaluationContext: ImmutableContext())
+            }
+            // A sentinel default, so the assertion cannot pass by falling back.
+            XCTAssertEqual(
+                OpenFeatureAPI.shared.getClient().getStringValue(
+                    key: flagKey, defaultValue: "<unset>"),
+                capture(matches, 1))
+        }
+    }
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Steps/DetailsSteps.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Steps/DetailsSteps.swift
@@ -1,0 +1,108 @@
+import CucumberSwift
+import Foundation
+import OpenFeature
+import XCTest
+
+extension Cucumber {
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    func registerDetailsSteps() {
+        registerBooleanAndStringDetailsSteps()
+        registerNumericDetailsSteps()
+        registerObjectDetailsSteps()
+    }
+
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    private func registerBooleanAndStringDetailsSteps() {
+        when(EvaluationPatterns.booleanDetails) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.booleanDetails = OpenFeatureAPI.shared.getClient().getBooleanDetails(
+                key: capture(matches, 1),
+                defaultValue: GherkinArguments.bool(capture(matches, 2)))
+        }
+        then(EvaluationPatterns.booleanDetailsResult) { matches, _ in
+            guard let details = ScenarioState.current.booleanDetails else {
+                XCTFail("no boolean details captured in this scenario")
+                return
+            }
+            XCTAssertEqual(details.value, GherkinArguments.bool(capture(matches, 1)))
+            XCTAssertEqual(details.variant, capture(matches, 2))
+            XCTAssertEqual(details.reason, capture(matches, 3))
+        }
+
+        when(EvaluationPatterns.stringDetails) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.stringDetails = OpenFeatureAPI.shared.getClient().getStringDetails(
+                key: capture(matches, 1), defaultValue: capture(matches, 2))
+        }
+        then(EvaluationPatterns.stringDetailsResult) { matches, _ in
+            guard let details = ScenarioState.current.stringDetails else {
+                XCTFail("no string details captured in this scenario")
+                return
+            }
+            XCTAssertEqual(details.value, capture(matches, 1))
+            XCTAssertEqual(details.variant, capture(matches, 2))
+            XCTAssertEqual(details.reason, capture(matches, 3))
+        }
+    }
+
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    private func registerNumericDetailsSteps() {
+        when(EvaluationPatterns.integerDetails) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.integerDetails = OpenFeatureAPI.shared.getClient().getIntegerDetails(
+                key: capture(matches, 1),
+                defaultValue: GherkinArguments.integer(capture(matches, 2)))
+        }
+        then(EvaluationPatterns.integerDetailsResult) { matches, _ in
+            guard let details = ScenarioState.current.integerDetails else {
+                XCTFail("no integer details captured in this scenario")
+                return
+            }
+            XCTAssertEqual(details.value, GherkinArguments.integer(capture(matches, 1)))
+            XCTAssertEqual(details.variant, capture(matches, 2))
+            XCTAssertEqual(details.reason, capture(matches, 3))
+        }
+
+        when(EvaluationPatterns.floatDetails) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.doubleDetails = OpenFeatureAPI.shared.getClient().getDoubleDetails(
+                key: capture(matches, 1),
+                defaultValue: GherkinArguments.double(capture(matches, 2)))
+        }
+        then(EvaluationPatterns.floatDetailsResult) { matches, _ in
+            guard let details = ScenarioState.current.doubleDetails else {
+                XCTFail("no float details captured in this scenario")
+                return
+            }
+            XCTAssertEqual(details.value, GherkinArguments.double(capture(matches, 1)))
+            XCTAssertEqual(details.variant, capture(matches, 2))
+            XCTAssertEqual(details.reason, capture(matches, 3))
+        }
+    }
+
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    private func registerObjectDetailsSteps() {
+        when(EvaluationPatterns.objectDetails) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.objectDetails = OpenFeatureAPI.shared.getClient().getObjectDetails(
+                key: capture(matches, 1), defaultValue: .null)
+        }
+        then(EvaluationPatterns.objectDetailsResult) { matches, _ in
+            GherkinArguments.assertObjectPayload(ScenarioState.current.objectDetails?.value, matches)
+        }
+        // An `And` step whose primary keyword is Then, so `then` matches it.
+        then(EvaluationPatterns.variantAndReason) { matches, _ in
+            guard let details = ScenarioState.current.objectDetails else {
+                XCTFail("no object details captured in this scenario")
+                return
+            }
+            XCTAssertEqual(details.variant, capture(matches, 1))
+            XCTAssertEqual(details.reason, capture(matches, 2))
+        }
+    }
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Steps/ErrorSteps.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Steps/ErrorSteps.swift
@@ -1,0 +1,44 @@
+import CucumberSwift
+import Foundation
+import OpenFeature
+import XCTest
+
+extension Cucumber {
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    func registerErrorSteps() {
+        when(EvaluationPatterns.missingFlagDetails) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.stringFallback = capture(matches, 2)
+            state.stringDetails = OpenFeatureAPI.shared.getClient().getStringDetails(
+                key: capture(matches, 1), defaultValue: capture(matches, 2))
+        }
+        then(EvaluationPatterns.defaultStringResult) { _, _ in
+            let state = ScenarioState.current
+            XCTAssertEqual(state.stringDetails?.value, state.stringFallback)
+        }
+        then(EvaluationPatterns.flagNotFoundReason) { matches, _ in
+            let details = ScenarioState.current.stringDetails
+            XCTAssertEqual(details?.reason, Reason.error.rawValue)
+            XCTAssertEqual(details?.errorCode, GherkinArguments.errorCode(capture(matches, 1)))
+        }
+
+        when(EvaluationPatterns.wrongTypeDetails) { matches, _ in
+            let state = ScenarioState.current
+            let fallback = GherkinArguments.integer(capture(matches, 2))
+            state.flagKey = capture(matches, 1)
+            state.integerFallback = fallback
+            state.integerDetails = OpenFeatureAPI.shared.getClient().getIntegerDetails(
+                key: capture(matches, 1), defaultValue: fallback)
+        }
+        then(EvaluationPatterns.defaultIntegerResult) { _, _ in
+            let state = ScenarioState.current
+            XCTAssertEqual(state.integerDetails?.value, state.integerFallback)
+        }
+        then(EvaluationPatterns.typeMismatchReason) { matches, _ in
+            let details = ScenarioState.current.integerDetails
+            XCTAssertEqual(details?.reason, Reason.error.rawValue)
+            XCTAssertEqual(details?.errorCode, GherkinArguments.errorCode(capture(matches, 1)))
+        }
+    }
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Steps/EvaluationPatterns.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Steps/EvaluationPatterns.swift
@@ -1,0 +1,51 @@
+// swiftlint:disable line_length
+// swift-format-ignore-file
+
+/// Every step in `spec/specification/assets/gherkin/evaluation.feature`.
+///
+/// Patterns must stay `^...$`-anchored: CucumberSwift matches unanchored and lets the last match
+/// win, so `a flag with key "..."` would otherwise also claim `a boolean flag with key "..."`.
+enum EvaluationPatterns {
+    // Background
+    static let stableProvider = #"^a stable provider$"#
+
+    // Basic evaluation
+    static let booleanValue        = #"^a boolean flag with key "([^"]*)" is evaluated with default value "([^"]*)"$"#
+    static let booleanValueResult  = #"^the resolved boolean value should be "([^"]*)"$"#
+    static let stringValue         = #"^a string flag with key "([^"]*)" is evaluated with default value "([^"]*)"$"#
+    static let stringValueResult   = #"^the resolved string value should be "([^"]*)"$"#
+    static let integerValue        = #"^an integer flag with key "([^"]*)" is evaluated with default value (-?\d+)$"#
+    static let integerValueResult  = #"^the resolved integer value should be (-?\d+)$"#
+    static let floatValue          = #"^a float flag with key "([^"]*)" is evaluated with default value (-?\d+\.\d+)$"#
+    static let floatValueResult    = #"^the resolved float value should be (-?\d+\.\d+)$"#
+    static let objectValue         = #"^an object flag with key "([^"]*)" is evaluated with a null default value$"#
+    static let objectValueResult   = #"^the resolved object value should be contain fields "([^"]*)", "([^"]*)", and "([^"]*)", with values "([^"]*)", "([^"]*)" and (-?\d+), respectively$"#
+
+    // Detailed evaluation
+    static let booleanDetails       = #"^a boolean flag with key "([^"]*)" is evaluated with details and default value "([^"]*)"$"#
+    static let booleanDetailsResult = #"^the resolved boolean details value should be "([^"]*)", the variant should be "([^"]*)", and the reason should be "([^"]*)"$"#
+    static let stringDetails        = #"^a string flag with key "([^"]*)" is evaluated with details and default value "([^"]*)"$"#
+    static let stringDetailsResult  = #"^the resolved string details value should be "([^"]*)", the variant should be "([^"]*)", and the reason should be "([^"]*)"$"#
+    static let integerDetails       = #"^an integer flag with key "([^"]*)" is evaluated with details and default value (-?\d+)$"#
+    static let integerDetailsResult = #"^the resolved integer details value should be (-?\d+), the variant should be "([^"]*)", and the reason should be "([^"]*)"$"#
+    static let floatDetails         = #"^a float flag with key "([^"]*)" is evaluated with details and default value (-?\d+\.\d+)$"#
+    static let floatDetailsResult   = #"^the resolved float details value should be (-?\d+\.\d+), the variant should be "([^"]*)", and the reason should be "([^"]*)"$"#
+    static let objectDetails        = #"^an object flag with key "([^"]*)" is evaluated with details and a null default value$"#
+    static let objectDetailsResult  = #"^the resolved object details value should be contain fields "([^"]*)", "([^"]*)", and "([^"]*)", with values "([^"]*)", "([^"]*)" and (-?\d+), respectively$"#
+    static let variantAndReason     = #"^the variant should be "([^"]*)", and the reason should be "([^"]*)"$"#
+
+    // Context-aware evaluation
+    static let contextContainsKeys  = #"^context contains keys "([^"]*)", "([^"]*)", "([^"]*)", "([^"]*)" with values "([^"]*)", "([^"]*)", (-?\d+), "([^"]*)"$"#
+    static let untypedFlagValue     = #"^a flag with key "([^"]*)" is evaluated with default value "([^"]*)"$"#
+    static let stringResponse       = #"^the resolved string response should be "([^"]*)"$"#
+    static let emptyContextValue    = #"^the resolved flag value is "([^"]*)" when the context is empty$"#
+
+    // Errors
+    static let missingFlagDetails   = #"^a non-existent string flag with key "([^"]*)" is evaluated with details and a fallback value "([^"]*)"$"#
+    static let defaultStringResult  = #"^the default string value should be returned$"#
+    static let flagNotFoundReason   = #"^the reason should indicate an error and the error code should indicate a missing flag with "([^"]*)"$"#
+    static let wrongTypeDetails     = #"^a string flag with key "([^"]*)" is evaluated as an integer, with details and a fallback value (-?\d+)$"#
+    static let defaultIntegerResult = #"^the default integer value should be returned$"#
+    static let typeMismatchReason   = #"^the reason should indicate an error and the error code should indicate a type mismatch with "([^"]*)"$"#
+}
+// swiftlint:enable line_length

--- a/e2e/Tests/OpenFeatureE2ETests/Steps/ProviderSteps.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Steps/ProviderSteps.swift
@@ -1,0 +1,36 @@
+import CucumberSwift
+import Foundation
+import OpenFeature
+import XCTest
+
+extension Cucumber {
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    func registerLifecycleHooks() {
+        BeforeScenario { _ in
+            // Forces every scenario through its Background step.
+            ScenarioState.clear()
+        }
+        AfterScenario { _ in
+            OpenFeatureAPI.shared.clearProvider()
+            ScenarioState.clear()
+        }
+    }
+
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    func registerProviderSteps() {
+        given(EvaluationPatterns.stableProvider) { _, _ in
+            ScenarioState.reset()
+            // The empty `initialContext` makes the suite order-independent: the evaluation
+            // context is global, and one scenario mutates it.
+            AsyncBridge.run {
+                await OpenFeatureAPI.shared.setProviderAndWait(
+                    provider: InMemoryProvider(flags: EvaluationFlags.all),
+                    initialContext: ImmutableContext())
+            }
+            XCTAssertEqual(
+                OpenFeatureAPI.shared.getProviderStatus(),
+                .ready,
+                "InMemoryProvider should be ready once setProviderAndWait returns")
+        }
+    }
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Steps/StepRegistration.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Steps/StepRegistration.swift
@@ -1,0 +1,57 @@
+import CucumberSwift
+import Foundation
+import XCTest
+
+// CucumberSwift's regex step API is deprecated in favour of Swift `Regex` literals, which require
+// iOS 16 / macOS 13 -- above this SDK's floor. Marking these wrappers and their callers deprecated
+// confines the warning.
+//
+// Patterns must be `String`-typed values, never literals: a literal binds to the
+// `CucumberExpression` overload, because the regex overloads are `@_disfavoredOverload`.
+
+@available(*, deprecated, message: "Wraps CucumberSwift's deprecated regex step API")
+func given(
+    _ pattern: String,
+    line: Int = #line,
+    file: StaticString = #filePath,
+    _ body: @escaping ([String], Step) throws -> Void
+) {
+    Given(pattern, callback: body, line: line, file: file)
+}
+
+@available(*, deprecated, message: "Wraps CucumberSwift's deprecated regex step API")
+func when(
+    _ pattern: String,
+    line: Int = #line,
+    file: StaticString = #filePath,
+    _ body: @escaping ([String], Step) throws -> Void
+) {
+    When(pattern, callback: body, line: line, file: file)
+}
+
+@available(*, deprecated, message: "Wraps CucumberSwift's deprecated regex step API")
+func then(
+    _ pattern: String,
+    line: Int = #line,
+    file: StaticString = #filePath,
+    _ body: @escaping ([String], Step) throws -> Void
+) {
+    Then(pattern, callback: body, line: line, file: file)
+}
+
+/// Fails the step rather than trapping if a pattern and its consumer have drifted apart.
+func capture(
+    _ matches: [String],
+    _ index: Int,
+    file: StaticString = #filePath,
+    line: UInt = #line
+) -> String {
+    guard matches.indices.contains(index) else {
+        XCTFail(
+            "Step pattern produced \(matches.count) groups, wanted group \(index)",
+            file: file,
+            line: line)
+        return ""
+    }
+    return matches[index]
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Steps/ValueSteps.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Steps/ValueSteps.swift
@@ -1,0 +1,65 @@
+import CucumberSwift
+import Foundation
+import OpenFeature
+import XCTest
+
+extension Cucumber {
+    @available(*, deprecated, message: "See StepRegistration.swift")
+    func registerValueSteps() {
+        when(EvaluationPatterns.booleanValue) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.booleanValue = OpenFeatureAPI.shared.getClient().getBooleanValue(
+                key: capture(matches, 1),
+                defaultValue: GherkinArguments.bool(capture(matches, 2)))
+        }
+        then(EvaluationPatterns.booleanValueResult) { matches, _ in
+            XCTAssertEqual(
+                ScenarioState.current.booleanValue, GherkinArguments.bool(capture(matches, 1)))
+        }
+
+        when(EvaluationPatterns.stringValue) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.stringValue = OpenFeatureAPI.shared.getClient().getStringValue(
+                key: capture(matches, 1), defaultValue: capture(matches, 2))
+        }
+        then(EvaluationPatterns.stringValueResult) { matches, _ in
+            XCTAssertEqual(ScenarioState.current.stringValue, capture(matches, 1))
+        }
+
+        when(EvaluationPatterns.integerValue) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.integerValue = OpenFeatureAPI.shared.getClient().getIntegerValue(
+                key: capture(matches, 1),
+                defaultValue: GherkinArguments.integer(capture(matches, 2)))
+        }
+        then(EvaluationPatterns.integerValueResult) { matches, _ in
+            XCTAssertEqual(
+                ScenarioState.current.integerValue, GherkinArguments.integer(capture(matches, 1)))
+        }
+
+        when(EvaluationPatterns.floatValue) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.doubleValue = OpenFeatureAPI.shared.getClient().getDoubleValue(
+                key: capture(matches, 1),
+                defaultValue: GherkinArguments.double(capture(matches, 2)))
+        }
+        then(EvaluationPatterns.floatValueResult) { matches, _ in
+            XCTAssertEqual(
+                ScenarioState.current.doubleValue, GherkinArguments.double(capture(matches, 1)))
+        }
+
+        when(EvaluationPatterns.objectValue) { matches, _ in
+            let state = ScenarioState.current
+            state.flagKey = capture(matches, 1)
+            state.objectValue = OpenFeatureAPI.shared.getClient().getObjectValue(
+                key: capture(matches, 1), defaultValue: .null)
+        }
+        then(EvaluationPatterns.objectValueResult) { matches, _ in
+            GherkinArguments.assertObjectPayload(ScenarioState.current.objectValue, matches)
+        }
+    }
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Support/AsyncBridge.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Support/AsyncBridge.swift
@@ -1,0 +1,24 @@
+import Foundation
+import XCTest
+
+/// Runs `async` SDK calls from CucumberSwift's synchronous step closures. `XCTWaiter` rather than
+/// a `DispatchSemaphore`, which would deadlock the moment a provider or hook hopped to the main queue.
+enum AsyncBridge {
+    static let defaultTimeout: TimeInterval = 10
+
+    static func run(
+        timeout: TimeInterval = AsyncBridge.defaultTimeout,
+        file: StaticString = #filePath,
+        line: UInt = #line,
+        _ operation: @escaping @Sendable () async -> Void
+    ) {
+        let expectation = XCTestExpectation(description: "async work in Gherkin step")
+        Task {
+            await operation()
+            expectation.fulfill()
+        }
+        if XCTWaiter().wait(for: [expectation], timeout: timeout) != .completed {
+            XCTFail("Timed out after \(timeout)s waiting for async work in step", file: file, line: line)
+        }
+    }
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Support/EvaluationFlags.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Support/EvaluationFlags.swift
@@ -1,0 +1,54 @@
+import Foundation
+import OpenFeature
+
+/// The flags `evaluation.feature` expects. Do not tidy these values -- the Gherkin asserts the
+/// literals.
+enum EvaluationFlags {
+    /// `customer` is a boolean, not the string the Gherkin quotes. See `GherkinArguments.boolOrString`.
+    private static let expectedContext: [String: Value] = [
+        "fn": .string("Sulisław"),
+        "ln": .string("Świętopełk"),
+        "age": .integer(29),
+        "customer": .boolean(false),
+    ]
+
+    private static let contextAwareEvaluator: InMemoryFlag.ContextEvaluator = { _, context in
+        let matched = expectedContext.allSatisfy { key, expected in
+            context?.getValue(key: key) == expected
+        }
+        return matched ? "internal" : nil
+    }
+
+    static let all: [String: InMemoryFlag] = [
+        "boolean-flag": InMemoryFlag(
+            variants: ["on": .boolean(true), "off": .boolean(false)],
+            defaultVariant: "on"),
+        "string-flag": InMemoryFlag(
+            variants: ["greeting": .string("hi"), "parting": .string("bye")],
+            defaultVariant: "greeting"),
+        "integer-flag": InMemoryFlag(
+            variants: ["one": .integer(1), "ten": .integer(10)],
+            defaultVariant: "ten"),
+        "float-flag": InMemoryFlag(
+            variants: ["tenth": .double(0.1), "half": .double(0.5)],
+            defaultVariant: "half"),
+        "object-flag": InMemoryFlag(
+            variants: [
+                "empty": .structure([:]),
+                "template": .structure([
+                    "showImages": .boolean(true),
+                    "title": .string("Check out these pics!"),
+                    "imagesPerPage": .integer(100),
+                ]),
+            ],
+            defaultVariant: "template"),
+        // Deliberately a string flag: the "Type error" scenario evaluates it as an integer.
+        "wrong-flag": InMemoryFlag(
+            variants: ["one": .string("uno"), "two": .string("dos")],
+            defaultVariant: "one"),
+        "context-aware": InMemoryFlag(
+            variants: ["internal": .string("INTERNAL"), "external": .string("EXTERNAL")],
+            defaultVariant: "external",
+            contextEvaluator: contextAwareEvaluator),
+    ]
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Support/GherkinArguments.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Support/GherkinArguments.swift
@@ -1,0 +1,104 @@
+import Foundation
+import OpenFeature
+import XCTest
+
+/// Turns raw capture groups into Swift values, failing the step rather than trapping on bad input.
+enum GherkinArguments {
+    static func bool(_ raw: String, file: StaticString = #filePath, line: UInt = #line) -> Bool {
+        switch raw.lowercased() {
+        case "true":
+            return true
+        case "false":
+            return false
+        default:
+            XCTFail("Expected a boolean literal, got '\(raw)'", file: file, line: line)
+            return false
+        }
+    }
+
+    static func integer(_ raw: String, file: StaticString = #filePath, line: UInt = #line) -> Int64 {
+        guard let value = Int64(raw) else {
+            XCTFail("Expected an integer literal, got '\(raw)'", file: file, line: line)
+            return 0
+        }
+        return value
+    }
+
+    static func double(_ raw: String, file: StaticString = #filePath, line: UInt = #line) -> Double {
+        guard let value = Double(raw) else {
+            XCTFail("Expected a float literal, got '\(raw)'", file: file, line: line)
+            return 0
+        }
+        return value
+    }
+
+    /// The context step quotes its boolean, so `"false"` has to become `.boolean(false)` or the
+    /// `context-aware` targeting rule never matches.
+    static func boolOrString(_ raw: String) -> Value {
+        switch raw.lowercased() {
+        case "true":
+            return .boolean(true)
+        case "false":
+            return .boolean(false)
+        default:
+            return .string(raw)
+        }
+    }
+
+    /// The spec names error codes in SCREAMING_SNAKE_CASE while `ErrorCode`'s cases are camelCase.
+    static func errorCode(
+        _ raw: String,
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) -> ErrorCode? {
+        switch raw {
+        case "PROVIDER_NOT_READY":
+            return .providerNotReady
+        case "FLAG_NOT_FOUND":
+            return .flagNotFound
+        case "PARSE_ERROR":
+            return .parseError
+        case "TYPE_MISMATCH":
+            return .typeMismatch
+        case "TARGETING_KEY_MISSING":
+            return .targetingKeyMissing
+        case "INVALID_CONTEXT":
+            return .invalidContext
+        case "GENERAL":
+            return .general
+        case "PROVIDER_FATAL":
+            return .providerFatal
+        default:
+            XCTFail("Unknown error code '\(raw)' in the Gherkin", file: file, line: line)
+            return nil
+        }
+    }
+
+    /// Groups 1 to 3 are field names; 4 a boolean value, 5 a string value, 6 an integer value.
+    static func assertObjectPayload(
+        _ value: Value?,
+        _ matches: [String],
+        file: StaticString = #filePath,
+        line: UInt = #line
+    ) {
+        guard let structure = value?.asStructure() else {
+            XCTFail("Expected a structure, got \(String(describing: value))", file: file, line: line)
+            return
+        }
+        XCTAssertEqual(
+            structure[capture(matches, 1)],
+            .boolean(bool(capture(matches, 4))),
+            file: file,
+            line: line)
+        XCTAssertEqual(
+            structure[capture(matches, 2)],
+            .string(capture(matches, 5)),
+            file: file,
+            line: line)
+        XCTAssertEqual(
+            structure[capture(matches, 3)],
+            .integer(integer(capture(matches, 6))),
+            file: file,
+            line: line)
+    }
+}

--- a/e2e/Tests/OpenFeatureE2ETests/Support/ScenarioState.swift
+++ b/e2e/Tests/OpenFeatureE2ETests/Support/ScenarioState.swift
@@ -1,0 +1,47 @@
+import Foundation
+import OpenFeature
+
+/// Per-scenario state, installed by the `Given a stable provider` background step.
+///
+/// Step closures are registered once on the `Cucumber.shared` singleton and reused by every
+/// scenario, so state captured in `setupSteps()` would leak between scenarios.
+final class ScenarioState {
+    private static let lock = NSLock()
+    private static var storage: ScenarioState?
+
+    @discardableResult
+    static func reset() -> ScenarioState {
+        let state = ScenarioState()
+        lock.withLock { storage = state }
+        return state
+    }
+
+    static func clear() {
+        lock.withLock { storage = nil }
+    }
+
+    static var current: ScenarioState {
+        guard let state = lock.withLock({ storage }) else {
+            preconditionFailure(
+                "No scenario state: 'Given a stable provider' did not run for this scenario")
+        }
+        return state
+    }
+
+    var flagKey: String?
+
+    var booleanValue: Bool?
+    var stringValue: String?
+    var integerValue: Int64?
+    var doubleValue: Double?
+    var objectValue: Value?
+
+    var booleanDetails: FlagEvaluationDetails<Bool>?
+    var stringDetails: FlagEvaluationDetails<String>?
+    var integerDetails: FlagEvaluationDetails<Int64>?
+    var doubleDetails: FlagEvaluationDetails<Double>?
+    var objectDetails: FlagEvaluationDetails<Value>?
+
+    var stringFallback: String?
+    var integerFallback: Int64?
+}

--- a/scripts/e2e
+++ b/scripts/e2e
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Runs the OpenFeature specification's shared Gherkin suite against InMemoryProvider.
+#
+# The feature file is copied rather than symlinked: `swift test` copies the symlink itself while
+# Xcode follows it, so a symlink would pass locally and crash in CI.
+
+set -euo pipefail
+
+script_dir=$(cd "$(dirname "$0")" && pwd)
+root_dir=$(cd "$script_dir/.." && pwd)
+features_dir="$root_dir/e2e/Tests/OpenFeatureE2ETests/Features"
+source_feature="$root_dir/spec/specification/assets/gherkin/evaluation.feature"
+
+git -C "$root_dir" submodule update --init spec
+
+if [ ! -f "$source_feature" ]; then
+  echo "error: $source_feature is missing. Is the 'spec' submodule initialised?" >&2
+  exit 1
+fi
+
+# Only evaluation.feature: CucumberSwift enumerates the directory recursively and fails every
+# step it has no expression for.
+mkdir -p "$features_dir"
+rm -f "$features_dir"/*.feature
+cp "$source_feature" "$features_dir/evaluation.feature"
+
+cd "$root_dir/e2e"
+swift test "$@"

--- a/scripts/swift-format
+++ b/scripts/swift-format
@@ -5,4 +5,4 @@ set -e
 script_dir=$(dirname $0)
 root_dir="$script_dir/.."
 
-$root_dir/Tools/swift-format format -i --recursive --configuration $root_dir/.swift-format $root_dir/Sources $root_dir/Tests
+$root_dir/Tools/swift-format format -i --recursive --configuration $root_dir/.swift-format $root_dir/Sources $root_dir/Tests $root_dir/e2e/Tests


### PR DESCRIPTION
> Depends on #126 and rebased onto its head (`0f811f5`). #125 has merged; until #126 merges, this PR's diff also contains its three commits.

Closes #105.

## Intent

[Appendix A](https://openfeature.dev/specification/appendix-a#sdk-end-to-end-testing) requires end-to-end tests to run against an in-memory provider and be self-contained, using the shared Gherkin suite from [Appendix B](https://openfeature.dev/specification/appendix-b). This adds `open-feature/spec` as a submodule and runs `evaluation.feature` against `InMemoryProvider` through the public `OpenFeatureAPI` and `Client` surface, with no mocks or stubs anywhere in the path.

## Motivation

Nothing in this repository validated the SDK end to end. The unit tests each verify one component against a double, so a defect in the seam between them (how the client dispatches by flag type, what it does with a provider throw, whether the evaluation context reaches the provider at all) would not have been caught. The shared suite is also how the ecosystem checks that SDKs agree with each other, and this SDK was not running it. `evaluation.feature` is what js-sdk and go-sdk run today; `evaluation_v2.feature` is left for follow-up, because it additionally needs `test-flags.json` parsing, provider-state doubles, and metadata and data-table steps.

## Changes

### Implementation

- Add `open-feature/spec` as a submodule at `spec/`, pinned by commit with no `branch =` key, matching java-sdk and js-sdk.
- Add an `e2e/` Swift package, separate from the root package, depending on it by path and on CucumberSwift. CucumberSwift declares no watchOS support and uses `XCTAttachment`/`XCTContext` unconditionally, so a root test target would break the watchOS CI job and add CucumberSwift plus CucumberSwiftExpressions to every consumer's dependency graph. The root `Package.resolved` still pins `swift-log` alone.
- Declare the path dependency as `.package(name: "OpenFeature", path: "..")`, so package identity does not follow the checkout directory name.
- Add `scripts/e2e`, which initialises the submodule, copies `evaluation.feature` into the test target's gitignored `Features/` directory, then runs `swift test` in `e2e/`.
- Copy the feature file rather than symlink it: `swift test` copies a symlinked resource directory as a dangling symlink while Xcode follows it, so a symlink would pass locally and crash in CI. Copying one file also keeps `evaluation_v2`, `hooks`, `metadata` and `contextMerging` out of the bundle, which CucumberSwift would otherwise enumerate and fail on.
- Declare resources with `.copy`, not `.process`: `.process` flattens directories, and CucumberSwift resolves features via `bundle.url(forResource: "Features", withExtension: nil)`.
- Set the step implementation's `bundle` to `Bundle.module`, not `Bundle(for:)` as in CucumberSwift's own consumer test, because under SwiftPM the copied resources live in a sibling bundle rather than inside the `.xctest`.
- Map the spec's SCREAMING_SNAKE error-code names to `ErrorCode` cases in `GherkinArguments.errorCode(_:)`, failing the step on a code the Gherkin names but the SDK does not define. Java gets this from `ErrorCode.valueOf`; Swift's cases are camelCase, so the map is explicit and `ErrorCode`'s public representation stays untouched.
- Anchor all 32 step patterns as `^...$` in one file. CucumberSwift matches unanchored and case-insensitively and lets the last matching registration win, so an unanchored `a flag with key "..."` would silently claim `a boolean flag with key "..."`.
- Install per-scenario state from the `Given a stable provider` background step and clear it before every scenario. That step registers a fresh provider with an explicitly empty `initialContext`, which is what makes the suite order-independent: this is a static-context SDK, so the evaluation context is global and the context-aware scenario mutates it.
- Add a macOS-only `E2E` CI job that checks out with `submodules: recursive`.
- Exclude `e2e/.build` and `spec/` from SwiftLint, and extend `scripts/swift-format` to cover `e2e/Tests`.
- Document in `CONTRIBUTING.md` how to run the suite, why `swift test` inside `e2e/` traps on a fresh clone, why `--filter` silently matches zero tests, and how to bump the spec pin.

## Testing

- All 13 scenarios and 45 steps pass: boolean, string, integer, float and object values; the same five with details, asserting variant and reason; context-aware resolution followed by re-resolution with an emptied context; flag not found; type mismatch.
- CucumberSwift generates a stub test case for any step it cannot match, and the run produces none, so no step is silently unimplemented.
- The suite can actually fail: flipping `string-flag`'s default variant from `greeting` to `parting` fails only the three string steps that assert the resolved value.
- Mis-mapping `FLAG_NOT_FOUND` to `.parseError` fails only the `Flag not found` scenario, so the error-code map is load-bearing rather than decorative.
- Against #126's stricter `getObjectEvaluation`, which rejects non-`.structure` variants, all 13 scenarios still pass, because `object-flag`'s variants are both structures. Pointing its `template` variant at a scalar fails exactly the two object scenarios, which confirms the suite exercises that guard rather than passing around it.
- The root package is unaffected: `swift test` (168 tests) and `xcodebuild test -scheme OpenFeature` on the iOS simulator are both green, and the root `Package.resolved` is unchanged.

## Breaking Changes

None - test-only, plus a new submodule. A fresh clone that skips submodules is unaffected unless it runs `scripts/e2e`, which initialises the submodule itself.
